### PR TITLE
Add Terrain Paint Mode with non‑destructive height & biome layers

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import SettingsModal from './components/SettingsModal.jsx';
 import InfiniteHUD from './components/InfiniteHUD.jsx';
 import ExportModal from './components/ExportModal.jsx';
 import MinimapOverlay from './components/MinimapOverlay.jsx';
+import PaintPanel from './components/paint/PaintPanel.jsx';
 
 export default function App() {
   const canvasRef = useRef(null);
@@ -37,6 +38,7 @@ export default function App() {
   const [previewMode, setPreviewMode] = useState(false);
   const [toast, setToast] = useState(null);
   const [activeSection, setActiveSection] = useState('section-generate');
+  const [paintState, setPaintState] = useState({ enabled: false });
 
   const [worldMode, setWorldMode] = useState('studio');
   const [infiniteStats, setInfiniteStats] = useState(null);
@@ -87,6 +89,7 @@ export default function App() {
         onQualityChange: setQualityPreset,
         onTimeOfDayChange: setTimeOfDay,
         onPerfChange: setPerf,
+        onPaintState: setPaintState,
       },
     });
     engine.setCullingEnabled(cullingEnabled);
@@ -165,7 +168,8 @@ export default function App() {
   const handlePerfSetting = (key, value) => engine().setPerfSetting(key, value);
 
   const isInfinite = worldMode === 'infinite';
-  const showStudioUI = !previewMode && !isInfinite;
+  const paintMode = !!paintState?.enabled;
+  const showStudioUI = !previewMode && !isInfinite && !paintMode;
 
   return (
     <div id="app" className={`${previewMode ? 'preview-mode' : ''} ${isInfinite ? 'infinite-mode' : ''}`}>
@@ -184,6 +188,8 @@ export default function App() {
         onOpenSettings={() => setSettingsOpen(true)}
         onOpenExport={() => setExportModalOpen(true)}
         onToggleWorldMode={toggleWorldMode}
+        paintMode={paintMode}
+        onTogglePaintMode={() => engine().setPaintMode(!paintMode)}
       />
 
       <div id="main" className="app-shell">
@@ -218,6 +224,15 @@ export default function App() {
               boardSize={boardSize}
               baseRef={minimapBaseRef}
               overlayRef={minimapOverlayRef}
+            />
+          )}
+
+          {paintMode && (
+            <PaintPanel
+              paintState={paintState}
+              onSetting={(key, value) => engine().setPaintSetting(key, value)}
+              onClear={() => engine().clearPaintLayers()}
+              onExit={() => engine().setPaintMode(false)}
             />
           )}
 

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -12,6 +12,7 @@ export default function TopBar({
   previewMode, worldMode, onNew, onRandomize, onSave, onLoadJSON,
   onExportScreenshot, onExportHeightmap, onTogglePreview,
   onResetView, onToggleHelp, onOpenSettings, onOpenExport, onToggleWorldMode,
+  paintMode, onTogglePaintMode,
 }) {
   const [exportOpen, setExportOpen] = useState(false);
   const fileRef = useRef(null);
@@ -84,6 +85,14 @@ export default function TopBar({
             <button onClick={onExportHeightmap}>Heightmap (PNG)</button>
           </div>
         </div>
+        <button
+          className={`tb-btn${paintMode ? ' active' : ''}`}
+          onClick={onTogglePaintMode}
+          title="Paint terrain height, biomes, and masks"
+        >
+          <svg viewBox="0 0 16 16"><path d="M3 12c2-4 5-7 10-9-2 5-5 8-9 10z" stroke="currentColor" fill="none" strokeWidth="1.2"/><path d="M4 13c-1 .5-1.5 1-2 1 0-.7.4-1.5 1-2" stroke="currentColor" fill="none" strokeWidth="1.2"/></svg>
+          Paint Mode
+        </button>
         <button
           className={`tb-btn${worldMode === 'infinite' ? ' active' : ''}`}
           onClick={onToggleWorldMode}

--- a/src/components/paint/PaintPanel.jsx
+++ b/src/components/paint/PaintPanel.jsx
@@ -1,0 +1,68 @@
+import { SelectRow, SliderCtl } from '../controls.jsx';
+
+const TOOL_OPTIONS = [
+  { value: 'raise', label: 'Raise Height' },
+  { value: 'lower', label: 'Lower Height' },
+  { value: 'smooth', label: 'Smooth Terrain' },
+  { value: 'flatten', label: 'Flatten Terrain' },
+  { value: 'setHeight', label: 'Set Height' },
+  { value: 'biome', label: 'Paint Biome' },
+  { value: 'erase', label: 'Erase Paint' },
+];
+
+const BIOME_OPTIONS = [
+  { value: 'desert', label: 'Desert' },
+  { value: 'canyon', label: 'Canyon' },
+  { value: 'wetland', label: 'Wetland' },
+  { value: 'mountains', label: 'Mountains' },
+];
+
+const defs = {
+  brushSize: { label: 'Brush Size', min: 4, max: 900, step: 1, digits: 0, unit: ' u' },
+  strength: { label: 'Strength', min: 0.01, max: 1, step: 0.01, digits: 2 },
+  falloff: { label: 'Falloff', min: 0, max: 1, step: 0.01, digits: 2 },
+  targetHeight: { label: 'Target Height', min: -120, max: 900, step: 1, digits: 0, unit: ' u' },
+  layerOpacity: { label: 'Layer Opacity', min: 0, max: 1, step: 0.01, digits: 2 },
+};
+
+export default function PaintPanel({ paintState, onSetting, onClear, onExit }) {
+  const state = paintState ?? {};
+  const set = (key) => (value) => onSetting(key, value);
+  return (
+    <aside className="paint-panel">
+      <div className="paint-panel-header">
+        <div>
+          <div className="paint-kicker">Terrain Paint Mode</div>
+          <h2>Paint Layers</h2>
+        </div>
+        <button className="paint-exit" type="button" onClick={onExit}>Exit</button>
+      </div>
+
+      <div className="paint-section">
+        <div className="subsection-label">Tool</div>
+        <SelectRow label="Brush Tool" value={state.tool ?? 'raise'} options={TOOL_OPTIONS} onChange={set('tool')} />
+        {(state.tool === 'biome') && (
+          <SelectRow label="Biome Mask" value={state.biome ?? 'desert'} options={BIOME_OPTIONS} onChange={set('biome')} />
+        )}
+        {(state.tool === 'flatten' || state.tool === 'setHeight') && (
+          <SliderCtl def={defs.targetHeight} value={state.targetHeight ?? 120} onChange={set('targetHeight')} />
+        )}
+      </div>
+
+      <div className="paint-section">
+        <div className="subsection-label">Brush</div>
+        <SliderCtl def={defs.brushSize} value={state.brushSize ?? 90} onChange={set('brushSize')} />
+        <SliderCtl def={defs.strength} value={state.strength ?? 0.35} onChange={set('strength')} />
+        <SliderCtl def={defs.falloff} value={state.falloff ?? 0.75} onChange={set('falloff')} />
+        <p className="section-hint">Hold <b>Shift</b> and scroll over the viewport to resize the brush without zooming the page.</p>
+      </div>
+
+      <div className="paint-section">
+        <div className="subsection-label">Layer</div>
+        <SliderCtl def={defs.layerOpacity} value={state.layerOpacity ?? 1} onChange={set('layerOpacity')} />
+        <button className="wide-btn danger" type="button" onClick={onClear}>Clear Painted Layers</button>
+        <p className="section-hint">Paint is stored as override layers. Procedural generation remains intact and can be changed or regenerated underneath.</p>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/paint/PaintPanel.jsx
+++ b/src/components/paint/PaintPanel.jsx
@@ -54,7 +54,7 @@ export default function PaintPanel({ paintState, onSetting, onClear, onExit }) {
         <SliderCtl def={defs.brushSize} value={state.brushSize ?? 90} onChange={set('brushSize')} />
         <SliderCtl def={defs.strength} value={state.strength ?? 0.35} onChange={set('strength')} />
         <SliderCtl def={defs.falloff} value={state.falloff ?? 0.75} onChange={set('falloff')} />
-        <p className="section-hint">Hold <b>Shift</b> and scroll over the viewport to resize the brush without zooming the page.</p>
+        <p className="section-hint">Hold <b>Shift</b> and scroll to resize the brush. Right-click drag still orbits the Studio camera.</p>
       </div>
 
       <div className="paint-section">

--- a/src/engine/EditorControls.js
+++ b/src/engine/EditorControls.js
@@ -33,6 +33,7 @@ export class EditorControls {
 
     this.onFirstInteract = null;
     this.enabled = true;           // false while the studio player walks
+    this.inputMode = 'all';        // 'all' or 'orbitOnly' while paint mode owns left drag
     this._interacted = false;
     this._drag = null;             // { button, x, y }
 
@@ -89,6 +90,7 @@ export class EditorControls {
   _onDown(e) {
     if (!this.enabled) return;
     if (e.button !== 0 && e.button !== 2) return;
+    if (this.inputMode === 'orbitOnly' && e.button !== 2) return;
     this._markInteract();
     this._drag = { button: e.button, x: e.clientX, y: e.clientY };
     this.dom.setPointerCapture(e.pointerId);

--- a/src/engine/Engine.js
+++ b/src/engine/Engine.js
@@ -22,6 +22,7 @@ import { TerrainHeightSampler } from './terrain/TerrainHeightSampler.js';
 import { GpuHeightSampler } from './terrain/GpuHeightSampler.js';
 import { PlayerController } from './player/PlayerController.js';
 import { downloadPlanetStyleJSON, parsePlanetStyleJSON } from './export/TerrainPresetExporter.js';
+import { PaintModeManager } from '../paint/PaintModeManager.js';
 
 // ============================================================================
 // Terrain Studio engine. Framework-agnostic: owns the renderer/scene, the
@@ -84,6 +85,8 @@ export class Engine {
     this._matTrash = [];         // warm materials kept alive until programs are acquired
     this._warmGeo = new THREE.PlaneGeometry(1, 1);
     this.planetStyle = new PlanetStyleManager();
+    this.paintMode = null;
+    this.paintState = null;
 
     // World mode: 'studio' (single board) or 'infinite'
     this.worldMode = 'studio';
@@ -112,6 +115,7 @@ export class Engine {
     this._initRenderer();
     this._initScene(minimapBase, minimapOverlay);
     this._initControls();
+    this._initPaintMode();
 
     this.applyAll({ force: true });
     this._applyPerformance();
@@ -190,6 +194,24 @@ export class Engine {
   _initControls() {
     this.controls = new EditorControls(this.camera, this.canvas);
     this.controls.onFirstInteract = () => this.cb.onFirstInteract();
+  }
+
+  _initPaintMode() {
+    this.paintMode = new PaintModeManager({
+      scene: this.scene,
+      camera: this.camera,
+      domElement: this.canvas,
+      uniforms: this.uniforms,
+      controls: this.controls,
+      getBoardSize: () => this.boardSize,
+      getParams: () => this.params,
+      onChange: (state) => {
+        this.paintState = state;
+        if (this.cb.onPaintState) this.cb.onPaintState(state);
+      },
+      onToast: (msg) => this.cb.onToast(msg),
+    });
+    this.paintState = { ...this.paintMode.state };
   }
 
   // ------------------------------------------------------------ parameters
@@ -627,6 +649,7 @@ export class Engine {
    */
   setPlayerMode(enabled) {
     enabled = !!enabled;
+    if (enabled && this.paintMode?.state.enabled) this.setPaintMode(false);
     if (enabled === this.playerMode) return;
     this.playerMode = enabled;
 
@@ -669,10 +692,30 @@ export class Engine {
     if (this.cb.onPlayerMode) this.cb.onPlayerMode(this.playerMode);
   }
 
+  // -------------------------------------------------------------- paint mode
+
+  setPaintMode(enabled) {
+    if (enabled && this.playerMode) this.setPlayerMode(false);
+    if (enabled && this.worldMode !== 'studio') {
+      this.cb.onToast('Paint Mode is currently available in Studio mode');
+      return;
+    }
+    this.paintMode?.setEnabled(enabled);
+  }
+
+  setPaintSetting(key, value) {
+    this.paintMode?.setState({ [key]: value });
+  }
+
+  clearPaintLayers() {
+    this.paintMode?.clear();
+  }
+
   // -------------------------------------------------------------- world mode
 
   setWorldMode(mode) {
     if (mode === this.worldMode) return;
+    if (this.paintMode?.state.enabled) this.setPaintMode(false);
     // player physics is per-mode — always leave it cleanly before switching
     this.setPlayerMode(false);
     this.worldMode = mode;
@@ -1041,6 +1084,7 @@ export class Engine {
       version: 1,
       savedAt: new Date().toISOString(),
       params: this.params,
+      paint: this.paintMode?.serialize(),
     };
     const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
     this._download(URL.createObjectURL(blob), `terrain-seed-${this.params.seed}.json`);
@@ -1063,6 +1107,7 @@ export class Engine {
     this._syncPlanetStyleToParams();
     this.cb.onParams({ ...this.params });
     this.applyAll({ force: true });
+    if (json?.paint) this.paintMode?.load(json.paint);
     this.cb.onToast(`Loaded seed ${this.params.seed}`);
   }
 
@@ -1189,6 +1234,8 @@ export class Engine {
       dt, this.uniforms.uTime.value, this.camera.position.y, waterLevel, this.uniforms
     );
 
+    this.paintMode?.update(dt);
+
     if (this.worldMode === 'infinite') {
       this._tickInfinite(dt, now);
     } else {
@@ -1303,6 +1350,7 @@ export class Engine {
     this._disposed = true;
     this._resizeObserver.disconnect();
     this.renderer.setAnimationLoop(null);
+    if (this.paintMode) { this.paintMode.dispose(); this.paintMode = null; }
     if (this.player) { this.player.dispose(); this.player = null; }
     if (this.heightSampler) { this.heightSampler.dispose(); this.heightSampler = null; }
     if (this.worldMode === 'infinite') this._exitInfiniteMode();

--- a/src/engine/Engine.js
+++ b/src/engine/Engine.js
@@ -729,6 +729,10 @@ export class Engine {
   }
 
   _enterInfiniteMode() {
+    // Infinite exploration stays fully procedural; Studio paint layers are
+    // board-local overrides and are restored when returning to Studio mode.
+    this.uniforms.uPaintEnabled.value = 0;
+
     // Hide studio objects
     this.board.group.visible = false;
     this.plinth.visible = false;
@@ -870,6 +874,7 @@ export class Engine {
 
     // Restore uniforms
     this._applyUniforms();
+    this.uniforms.uPaintEnabled.value = 1;
 
     // Restore scene background
     this.scene.background = new THREE.Color(0x0b0e14);

--- a/src/engine/terrain/TerrainMaterial.js
+++ b/src/engine/terrain/TerrainMaterial.js
@@ -88,11 +88,16 @@ void main() {
 
   Climate cl = climateAt(xz * uFrequency + uSeedOffset);
   BiomeWeights bw = biomeWeightsAt(cl);
+  vec4 paintedBiome = paintBiomeAt(xz);
+  bw.desert = clamp(max(bw.desert, paintedBiome.r), 0.0, 1.0);
+  bw.canyon = clamp(max(bw.canyon, paintedBiome.g), 0.0, 1.0);
+  bw.wetland = clamp(max(bw.wetland, paintedBiome.b), 0.0, 1.0);
+  bw.mountains = clamp(max(bw.mountains, paintedBiome.a), 0.0, 1.0);
 
   float eps = uEps;
-  float hC = shapeHeight(xz, cl);
-  float hX = shapeHeight(xz + vec2(eps, 0.0), cl);
-  float hZ = shapeHeight(xz + vec2(0.0, eps), cl);
+  float hC = heightAt(xz);
+  float hX = heightAt(xz + vec2(eps, 0.0));
+  float hZ = heightAt(xz + vec2(0.0, eps));
 
   if (uColorMode > 0.5) {
     float h01 = clamp(hC / max(uHeightScale, 1e-3), 0.0, 1.0);
@@ -200,6 +205,13 @@ export function createTerrainUniforms() {
     uFogColor:       { value: new THREE.Color(0x0b0e14) },
     uFogDensity:     { value: 0.000045 },
     uTime:           { value: 0 },
+    uPaintEnabled:   { value: 0 },
+    uPaintOpacity:   { value: 1 },
+    uPaintBoardSize: { value: 1024 },
+    uPaintResolution:{ value: 512 },
+    uPaintHeightRange: { value: 180 },
+    uPaintHeightTexture: { value: null },
+    uPaintBiomeTexture: { value: null },
     ...paletteUniforms,
   };
 }

--- a/src/engine/terrain/terrainGLSL.js
+++ b/src/engine/terrain/terrainGLSL.js
@@ -21,6 +21,13 @@ uniform vec3  uSunDir;         // normalized, pointing FROM surface TO sun
 uniform vec3  uFogColor;
 uniform float uFogDensity;
 uniform float uTime;
+uniform float uPaintEnabled;
+uniform float uPaintOpacity;
+uniform float uPaintBoardSize;
+uniform float uPaintResolution;
+uniform float uPaintHeightRange;
+uniform sampler2D uPaintHeightTexture;
+uniform sampler2D uPaintBiomeTexture;
 `;
 
 export const NOISE_GLSL = /* glsl */ `
@@ -171,8 +178,27 @@ float shapeHeight(vec2 xz, Climate c) {
   return clamp(h, 0.0, 1.35) * uHeightScale;
 }
 
+vec2 paintUvAt(vec2 xz) {
+  return xz / max(uPaintBoardSize, 1.0) + vec2(0.5);
+}
+
+float paintHeightOffsetAt(vec2 xz) {
+  if (uPaintEnabled < 0.5) return 0.0;
+  vec2 uv = paintUvAt(xz);
+  if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0) return 0.0;
+  float encoded = texture2D(uPaintHeightTexture, uv).r;
+  return (encoded - 0.5) * 2.0 * uPaintHeightRange * uPaintOpacity;
+}
+
+vec4 paintBiomeAt(vec2 xz) {
+  if (uPaintEnabled < 0.5) return vec4(0.0);
+  vec2 uv = paintUvAt(xz);
+  if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0) return vec4(0.0);
+  return texture2D(uPaintBiomeTexture, uv) * uPaintOpacity;
+}
+
 float heightAt(vec2 xz) {
-  return shapeHeight(xz, climateAt(xz * uFrequency + uSeedOffset));
+  return shapeHeight(xz, climateAt(xz * uFrequency + uSeedOffset)) + paintHeightOffsetAt(xz);
 }
 
 // Moisture field for biome blending — now sourced from the climate system.

--- a/src/paint/PaintBrushCursor.js
+++ b/src/paint/PaintBrushCursor.js
@@ -1,0 +1,40 @@
+import * as THREE from 'three';
+
+export class PaintBrushCursor {
+  constructor(scene) {
+    this.group = new THREE.Group();
+    this.group.name = 'paint-brush-cursor';
+    this.group.visible = false;
+    this.group.renderOrder = 9999;
+
+    const ringGeo = new THREE.RingGeometry(0.96, 1.0, 96);
+    ringGeo.rotateX(-Math.PI / 2);
+    const mat = new THREE.MeshBasicMaterial({
+      color: 0x7dd3fc,
+      transparent: true,
+      opacity: 0.9,
+      depthTest: false,
+      depthWrite: false,
+      side: THREE.DoubleSide,
+    });
+    this.ring = new THREE.Mesh(ringGeo, mat);
+    this.ring.renderOrder = 9999;
+    this.group.add(this.ring);
+    scene.add(this.group);
+  }
+
+  setVisible(visible) { this.group.visible = !!visible; }
+
+  update(point, radius) {
+    if (!point) return this.setVisible(false);
+    this.group.position.set(point.x, point.y + 2, point.z);
+    this.group.scale.setScalar(Math.max(1, radius));
+    this.setVisible(true);
+  }
+
+  dispose() {
+    this.group.parent?.remove(this.group);
+    this.ring.geometry.dispose();
+    this.ring.material.dispose();
+  }
+}

--- a/src/paint/PaintLayerManager.js
+++ b/src/paint/PaintLayerManager.js
@@ -1,0 +1,182 @@
+import * as THREE from 'three';
+
+const NEUTRAL_HEIGHT = 128;
+
+function clamp(v, a, b) { return Math.max(a, Math.min(b, v)); }
+function smoothstep(t) { return t * t * (3 - 2 * t); }
+
+export const PAINT_BIOME_CHANNELS = {
+  desert: 0,
+  canyon: 1,
+  wetland: 2,
+  mountains: 3,
+};
+
+export class PaintLayerManager {
+  constructor({ uniforms, boardSize, resolution = 512, heightRange = 180 }) {
+    this.uniforms = uniforms;
+    this.resolution = resolution;
+    this.boardSize = boardSize;
+    this.heightRange = heightRange;
+    this.heightData = new Uint8Array(resolution * resolution * 4);
+    this.biomeData = new Uint8Array(resolution * resolution * 4);
+    this.heightData.fill(NEUTRAL_HEIGHT);
+    for (let i = 3; i < this.heightData.length; i += 4) this.heightData[i] = 255;
+
+    this.heightTexture = new THREE.DataTexture(this.heightData, resolution, resolution, THREE.RGBAFormat, THREE.UnsignedByteType);
+    this.heightTexture.colorSpace = THREE.NoColorSpace;
+    this.heightTexture.wrapS = THREE.ClampToEdgeWrapping;
+    this.heightTexture.wrapT = THREE.ClampToEdgeWrapping;
+    this.heightTexture.minFilter = THREE.LinearFilter;
+    this.heightTexture.magFilter = THREE.LinearFilter;
+    this.heightTexture.needsUpdate = true;
+
+    this.biomeTexture = new THREE.DataTexture(this.biomeData, resolution, resolution, THREE.RGBAFormat, THREE.UnsignedByteType);
+    this.biomeTexture.colorSpace = THREE.NoColorSpace;
+    this.biomeTexture.wrapS = THREE.ClampToEdgeWrapping;
+    this.biomeTexture.wrapT = THREE.ClampToEdgeWrapping;
+    this.biomeTexture.minFilter = THREE.LinearFilter;
+    this.biomeTexture.magFilter = THREE.LinearFilter;
+    this.biomeTexture.needsUpdate = true;
+
+    this._bindUniforms();
+  }
+
+  _bindUniforms() {
+    this.uniforms.uPaintHeightTexture.value = this.heightTexture;
+    this.uniforms.uPaintBiomeTexture.value = this.biomeTexture;
+    this.uniforms.uPaintResolution.value = this.resolution;
+    this.uniforms.uPaintHeightRange.value = this.heightRange;
+    this.uniforms.uPaintEnabled.value = 1;
+  }
+
+  setBoardSize(boardSize) {
+    this.boardSize = boardSize;
+  }
+
+  worldToPixel(x, z) {
+    const u = (x / this.boardSize) + 0.5;
+    const v = (z / this.boardSize) + 0.5;
+    return {
+      px: u * (this.resolution - 1),
+      py: v * (this.resolution - 1),
+      u,
+      v,
+    };
+  }
+
+  sampleHeightOffset(x, z) {
+    const { px, py } = this.worldToPixel(x, z);
+    const ix = clamp(Math.round(px), 0, this.resolution - 1);
+    const iy = clamp(Math.round(py), 0, this.resolution - 1);
+    const value = this.heightData[(iy * this.resolution + ix) * 4] / 255;
+    return (value - 0.5) * 2 * this.heightRange;
+  }
+
+  stamp({ x, z, radius, strength, falloff, tool, targetHeight = 0, biome = 'desert', baseHeightAt }) {
+    const center = this.worldToPixel(x, z);
+    const pixelRadius = Math.max(1, radius / this.boardSize * this.resolution);
+    const minX = clamp(Math.floor(center.px - pixelRadius), 0, this.resolution - 1);
+    const maxX = clamp(Math.ceil(center.px + pixelRadius), 0, this.resolution - 1);
+    const minY = clamp(Math.floor(center.py - pixelRadius), 0, this.resolution - 1);
+    const maxY = clamp(Math.ceil(center.py + pixelRadius), 0, this.resolution - 1);
+    const delta = strength * 18;
+    const channel = PAINT_BIOME_CHANNELS[biome] ?? 0;
+
+    for (let py = minY; py <= maxY; py++) {
+      for (let px = minX; px <= maxX; px++) {
+        const dx = px - center.px;
+        const dy = py - center.py;
+        const dist = Math.hypot(dx, dy);
+        if (dist > pixelRadius) continue;
+        const radial = 1 - dist / pixelRadius;
+        const soft = falloff <= 0 ? 1 : smoothstep(clamp(radial / Math.max(falloff, 0.001), 0, 1));
+        const alpha = clamp(soft * strength, 0, 1);
+        const i = (py * this.resolution + px) * 4;
+
+        if (tool === 'biome') {
+          this.biomeData[i + channel] = Math.round(clamp(this.biomeData[i + channel] + alpha * 255, 0, 255));
+          continue;
+        }
+
+        if (tool === 'erase') {
+          this.heightData[i] = Math.round(this.heightData[i] + (NEUTRAL_HEIGHT - this.heightData[i]) * alpha);
+          for (let c = 0; c < 4; c++) this.biomeData[i + c] = Math.round(this.biomeData[i + c] * (1 - alpha));
+          continue;
+        }
+
+        const currentOffset = (this.heightData[i] / 255 - 0.5) * 2 * this.heightRange;
+        let nextOffset = currentOffset;
+        if (tool === 'raise') nextOffset = currentOffset + delta * soft;
+        else if (tool === 'lower') nextOffset = currentOffset - delta * soft;
+        else if (tool === 'setHeight' || tool === 'flatten') {
+          const wx = (px / (this.resolution - 1) - 0.5) * this.boardSize;
+          const wz = (py / (this.resolution - 1) - 0.5) * this.boardSize;
+          const base = baseHeightAt ? baseHeightAt(wx, wz) : 0;
+          const desiredOffset = targetHeight - base;
+          nextOffset = currentOffset + (desiredOffset - currentOffset) * alpha;
+        } else if (tool === 'smooth') {
+          let sum = 0;
+          let count = 0;
+          for (let oy = -2; oy <= 2; oy++) {
+            for (let ox = -2; ox <= 2; ox++) {
+              const sx = clamp(px + ox, 0, this.resolution - 1);
+              const sy = clamp(py + oy, 0, this.resolution - 1);
+              const ni = (sy * this.resolution + sx) * 4;
+              const nOffset = (this.heightData[ni] / 255 - 0.5) * 2 * this.heightRange;
+              const wx = (sx / (this.resolution - 1) - 0.5) * this.boardSize;
+              const wz = (sy / (this.resolution - 1) - 0.5) * this.boardSize;
+              sum += (baseHeightAt ? baseHeightAt(wx, wz) : 0) + nOffset;
+              count++;
+            }
+          }
+          const wx = (px / (this.resolution - 1) - 0.5) * this.boardSize;
+          const wz = (py / (this.resolution - 1) - 0.5) * this.boardSize;
+          const base = baseHeightAt ? baseHeightAt(wx, wz) : 0;
+          const desiredOffset = sum / count - base;
+          nextOffset = currentOffset + (desiredOffset - currentOffset) * alpha;
+        }
+        const encoded = clamp((nextOffset / this.heightRange / 2 + 0.5) * 255, 0, 255);
+        this.heightData[i] = Math.round(encoded);
+      }
+    }
+    this.heightTexture.needsUpdate = true;
+    this.biomeTexture.needsUpdate = true;
+  }
+
+  clear() {
+    this.heightData.fill(NEUTRAL_HEIGHT);
+    for (let i = 3; i < this.heightData.length; i += 4) this.heightData[i] = 255;
+    this.biomeData.fill(0);
+    this.heightTexture.needsUpdate = true;
+    this.biomeTexture.needsUpdate = true;
+  }
+
+  serialize() {
+    return {
+      version: 1,
+      resolution: this.resolution,
+      boardSize: this.boardSize,
+      heightRange: this.heightRange,
+      height: Array.from(this.heightData),
+      biome: Array.from(this.biomeData),
+    };
+  }
+
+  load(data) {
+    if (!data || data.resolution !== this.resolution) return false;
+    if (data.height?.length === this.heightData.length) this.heightData.set(data.height);
+    if (data.biome?.length === this.biomeData.length) this.biomeData.set(data.biome);
+    this.heightRange = data.heightRange ?? this.heightRange;
+    this.boardSize = data.boardSize ?? this.boardSize;
+    this.uniforms.uPaintHeightRange.value = this.heightRange;
+    this.heightTexture.needsUpdate = true;
+    this.biomeTexture.needsUpdate = true;
+    return true;
+  }
+
+  dispose() {
+    this.heightTexture.dispose();
+    this.biomeTexture.dispose();
+  }
+}

--- a/src/paint/PaintLayerManager.js
+++ b/src/paint/PaintLayerManager.js
@@ -116,25 +116,23 @@ export class PaintLayerManager {
           const desiredOffset = targetHeight - base;
           nextOffset = currentOffset + (desiredOffset - currentOffset) * alpha;
         } else if (tool === 'smooth') {
+          // Keep smoothing responsive by blurring the editable height-offset
+          // layer directly. Sampling procedural noise for every neighbor in a
+          // large brush can require tens of thousands of CPU FBM evaluations
+          // per stamp, which causes visible stalls. The procedural base remains
+          // intact; this smooths the non-destructive override layer.
+          const k = Math.max(1, Math.round(pixelRadius * 0.08));
           let sum = 0;
           let count = 0;
-          for (let oy = -2; oy <= 2; oy++) {
-            for (let ox = -2; ox <= 2; ox++) {
-              const sx = clamp(px + ox, 0, this.resolution - 1);
-              const sy = clamp(py + oy, 0, this.resolution - 1);
-              const ni = (sy * this.resolution + sx) * 4;
-              const nOffset = (this.heightData[ni] / 255 - 0.5) * 2 * this.heightRange;
-              const wx = (sx / (this.resolution - 1) - 0.5) * this.boardSize;
-              const wz = (sy / (this.resolution - 1) - 0.5) * this.boardSize;
-              sum += (baseHeightAt ? baseHeightAt(wx, wz) : 0) + nOffset;
+          for (let oy = -1; oy <= 1; oy++) {
+            for (let ox = -1; ox <= 1; ox++) {
+              const sx = clamp(px + ox * k, 0, this.resolution - 1);
+              const sy = clamp(py + oy * k, 0, this.resolution - 1);
+              sum += (this.heightData[(sy * this.resolution + sx) * 4] / 255 - 0.5) * 2 * this.heightRange;
               count++;
             }
           }
-          const wx = (px / (this.resolution - 1) - 0.5) * this.boardSize;
-          const wz = (py / (this.resolution - 1) - 0.5) * this.boardSize;
-          const base = baseHeightAt ? baseHeightAt(wx, wz) : 0;
-          const desiredOffset = sum / count - base;
-          nextOffset = currentOffset + (desiredOffset - currentOffset) * alpha;
+          nextOffset = currentOffset + (sum / count - currentOffset) * alpha;
         }
         const encoded = clamp((nextOffset / this.heightRange / 2 + 0.5) * 255, 0, 255);
         this.heightData[i] = Math.round(encoded);

--- a/src/paint/PaintModeManager.js
+++ b/src/paint/PaintModeManager.js
@@ -51,9 +51,11 @@ export class PaintModeManager {
   enable() {
     if (this.state.enabled) return;
     this.state.enabled = true;
-    this.controls.enabled = false;
+    this._previousControlInputMode = this.controls.inputMode ?? 'all';
+    this.controls.enabled = true;
+    this.controls.inputMode = 'orbitOnly';
     this._syncUniforms();
-    this.onToast?.('Paint Mode — left drag paints · Shift + wheel changes brush size');
+    this.onToast?.('Paint Mode — left drag paints · right drag orbits · Shift + wheel changes brush size');
     this._emit();
   }
 
@@ -62,6 +64,7 @@ export class PaintModeManager {
     this.state.enabled = false;
     this.isPainting = false;
     this.controls.enabled = true;
+    this.controls.inputMode = this._previousControlInputMode ?? 'all';
     this.cursor.setVisible(false);
     this._syncUniforms();
     this.onToast?.('Exited Paint Mode');
@@ -175,7 +178,8 @@ export class PaintModeManager {
   _stamp(force = false) {
     if (!this.hit) return;
     const now = performance.now();
-    if (!force && now - this._lastStamp < 24) return;
+    const minStampMs = this.state.tool === 'smooth' ? 80 : 24;
+    if (!force && now - this._lastStamp < minStampMs) return;
     this._lastStamp = now;
     this.layers.stamp({
       x: this.hit.x,

--- a/src/paint/PaintModeManager.js
+++ b/src/paint/PaintModeManager.js
@@ -1,0 +1,203 @@
+import * as THREE from 'three';
+import { PaintLayerManager } from './PaintLayerManager.js';
+import { PaintBrushCursor } from './PaintBrushCursor.js';
+import { TerrainHeightSampler } from '../engine/terrain/TerrainHeightSampler.js';
+
+const DEFAULT_STATE = {
+  enabled: false,
+  tool: 'raise',
+  brushSize: 90,
+  strength: 0.35,
+  falloff: 0.75,
+  targetHeight: 120,
+  biome: 'desert',
+  layerOpacity: 1,
+};
+
+export class PaintModeManager {
+  constructor({ scene, camera, domElement, uniforms, controls, getBoardSize, getParams, onChange, onToast }) {
+    this.scene = scene;
+    this.camera = camera;
+    this.domElement = domElement;
+    this.uniforms = uniforms;
+    this.controls = controls;
+    this.getBoardSize = getBoardSize;
+    this.getParams = getParams;
+    this.onChange = onChange;
+    this.onToast = onToast;
+    this.state = { ...DEFAULT_STATE };
+    this.layers = new PaintLayerManager({ uniforms, boardSize: getBoardSize() });
+    this.cursor = new PaintBrushCursor(scene);
+    this.cpuSampler = new TerrainHeightSampler(uniforms, () => ({ octaves: Math.round(getParams().octaves), infinite: false }));
+    this.raycaster = new THREE.Raycaster();
+    this.pointer = new THREE.Vector2();
+    this.hit = null;
+    this.isPainting = false;
+    this._lastStamp = 0;
+
+    this._onPointerMove = this._onPointerMove.bind(this);
+    this._onPointerDown = this._onPointerDown.bind(this);
+    this._onPointerUp = this._onPointerUp.bind(this);
+    this._onWheel = this._onWheel.bind(this);
+    this._onContextMenu = (e) => this.state.enabled && e.preventDefault();
+    this.domElement.addEventListener('pointermove', this._onPointerMove);
+    this.domElement.addEventListener('pointerdown', this._onPointerDown);
+    window.addEventListener('pointerup', this._onPointerUp);
+    this.domElement.addEventListener('wheel', this._onWheel, { passive: false });
+    this.domElement.addEventListener('contextmenu', this._onContextMenu);
+    this._syncUniforms();
+  }
+
+  enable() {
+    if (this.state.enabled) return;
+    this.state.enabled = true;
+    this.controls.enabled = false;
+    this._syncUniforms();
+    this.onToast?.('Paint Mode — left drag paints · Shift + wheel changes brush size');
+    this._emit();
+  }
+
+  disable() {
+    if (!this.state.enabled) return;
+    this.state.enabled = false;
+    this.isPainting = false;
+    this.controls.enabled = true;
+    this.cursor.setVisible(false);
+    this._syncUniforms();
+    this.onToast?.('Exited Paint Mode');
+    this._emit();
+  }
+
+  setEnabled(enabled) { enabled ? this.enable() : this.disable(); }
+
+  setState(patch) {
+    Object.assign(this.state, patch);
+    this.state.brushSize = Math.max(4, Math.min(900, this.state.brushSize));
+    this.state.strength = Math.max(0.01, Math.min(1, this.state.strength));
+    this.state.falloff = Math.max(0, Math.min(1, this.state.falloff));
+    this._syncUniforms();
+    this._emit();
+  }
+
+  clear() {
+    this.layers.clear();
+    this.onToast?.('Paint layers cleared');
+  }
+
+  serialize() { return this.layers.serialize(); }
+  load(data) { return this.layers.load(data); }
+
+  update() {
+    if (!this.state.enabled) return;
+    if (this.hit) this.cursor.update(this.hit, this.state.brushSize);
+    if (this.isPainting) this._stamp();
+  }
+
+  _syncUniforms() {
+    this.layers.setBoardSize(this.getBoardSize());
+    this.uniforms.uPaintEnabled.value = this.state.enabled ? 1 : 1;
+    this.uniforms.uPaintBoardSize.value = this.getBoardSize();
+    this.uniforms.uPaintOpacity.value = this.state.layerOpacity;
+  }
+
+  _emit() { this.onChange?.({ ...this.state }); }
+
+  _onPointerMove(e) {
+    if (!this.state.enabled) return;
+    this._updateHit(e);
+  }
+
+  _onPointerDown(e) {
+    if (!this.state.enabled || e.button !== 0) return;
+    e.preventDefault();
+    e.stopPropagation();
+    this.domElement.setPointerCapture?.(e.pointerId);
+    this._updateHit(e);
+    this.isPainting = true;
+    this._stamp(true);
+  }
+
+  _onPointerUp() { this.isPainting = false; }
+
+  _onWheel(e) {
+    if (!this.state.enabled || !e.shiftKey) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const factor = e.deltaY > 0 ? 0.9 : 1.1;
+    this.setState({ brushSize: Math.round(this.state.brushSize * factor) });
+  }
+
+  _updateHit(e) {
+    const rect = this.domElement.getBoundingClientRect();
+    this.pointer.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+    this.pointer.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+    this.raycaster.setFromCamera(this.pointer, this.camera);
+    this.hit = this._intersectHeightField(this.raycaster.ray);
+    this.cursor.update(this.hit, this.state.brushSize);
+  }
+
+  _heightAt(x, z, includePaint = true) {
+    const half = this.getBoardSize() / 2;
+    if (Math.abs(x) > half || Math.abs(z) > half) return null;
+    const base = this.cpuSampler.heightAt(x, z);
+    return includePaint ? base + this.layers.sampleHeightOffset(x, z) * this.state.layerOpacity : base;
+  }
+
+  _intersectHeightField(ray) {
+    const maxDist = Math.max(3000, this.getBoardSize() * 4);
+    let prevT = 0;
+    let prevD = ray.origin.y - (this._heightAt(ray.origin.x, ray.origin.z) ?? -Infinity);
+    const steps = 96;
+    for (let i = 1; i <= steps; i++) {
+      const t = (i / steps) * maxDist;
+      const p = ray.at(t, new THREE.Vector3());
+      const h = this._heightAt(p.x, p.z);
+      if (h == null) continue;
+      const d = p.y - h;
+      if (d <= 0 && prevD >= 0) {
+        let a = prevT, b = t;
+        for (let k = 0; k < 8; k++) {
+          const m = (a + b) * 0.5;
+          const q = ray.at(m, new THREE.Vector3());
+          const mh = this._heightAt(q.x, q.z);
+          if (q.y - mh > 0) a = m; else b = m;
+        }
+        const hit = ray.at((a + b) * 0.5, new THREE.Vector3());
+        hit.y = this._heightAt(hit.x, hit.z);
+        return hit;
+      }
+      prevT = t;
+      prevD = d;
+    }
+    return null;
+  }
+
+  _stamp(force = false) {
+    if (!this.hit) return;
+    const now = performance.now();
+    if (!force && now - this._lastStamp < 24) return;
+    this._lastStamp = now;
+    this.layers.stamp({
+      x: this.hit.x,
+      z: this.hit.z,
+      radius: this.state.brushSize,
+      strength: this.state.strength,
+      falloff: this.state.falloff,
+      tool: this.state.tool,
+      targetHeight: this.state.targetHeight,
+      biome: this.state.biome,
+      baseHeightAt: (x, z) => this._heightAt(x, z, false) ?? 0,
+    });
+  }
+
+  dispose() {
+    this.disable();
+    this.domElement.removeEventListener('pointermove', this._onPointerMove);
+    this.domElement.removeEventListener('pointerdown', this._onPointerDown);
+    window.removeEventListener('pointerup', this._onPointerUp);
+    this.domElement.removeEventListener('wheel', this._onWheel);
+    this.domElement.removeEventListener('contextmenu', this._onContextMenu);
+    this.cursor.dispose();
+    this.layers.dispose();
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1733,3 +1733,64 @@ body {
 .player-state-falling { color: #f0c560; }
 .player-state-swimming { color: #6db8f0; }
 .player-state-underwater { color: #4d8fd6; }
+
+/* ============ PAINT MODE ============ */
+.paint-panel {
+  position: absolute;
+  top: 14px;
+  left: 14px;
+  width: 300px;
+  max-height: calc(100% - 28px);
+  overflow-y: auto;
+  padding: 12px;
+  background: rgba(18, 22, 31, 0.96);
+  border: 1px solid var(--border-active);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-panel);
+  z-index: 20;
+  backdrop-filter: blur(10px);
+}
+.paint-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.paint-kicker {
+  color: var(--accent);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+}
+.paint-panel h2 {
+  margin-top: 2px;
+  color: #e8eef8;
+  font-size: 16px;
+}
+.paint-exit {
+  height: 28px;
+  padding: 0 10px;
+  color: var(--text-main);
+  background: var(--bg-control);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+.paint-exit:hover { border-color: var(--border-active); color: var(--accent); }
+.paint-section {
+  padding: 8px 0 4px;
+  border-bottom: 1px solid rgba(120, 150, 190, 0.08);
+}
+.paint-section:last-child { border-bottom: 0; }
+.wide-btn.danger {
+  border-color: rgba(229, 72, 77, 0.35);
+  color: #ffb4b4;
+}
+.wide-btn.danger:hover {
+  background: rgba(229, 72, 77, 0.12);
+  border-color: rgba(229, 72, 77, 0.6);
+}
+#viewport { touch-action: none; }


### PR DESCRIPTION
### Motivation
- Provide a Studio Paint Mode so users can visually edit terrain height and biome masks without destroying the underlying shader-driven procedural generation. 
- Keep painting non‑destructive and layered so procedural parameters can still be changed and paint can be cleared or exported later.
- Integrate painting into the existing UI and engine loop with stable ray-projected brush cursor, Shift+wheel resizing, and project-save persistence.

### Description
- Added a Paint manager and runtime: `src/paint/PaintModeManager.js` implements the paint workflow, input handling (pointer, left-drag painting, Shift+wheel brush resize), per-frame updates, and serialization; `src/paint/PaintBrushCursor.js` renders a depth-independent ring cursor; `src/paint/PaintLayerManager.js` stores editable textures for height offsets and biome channels and exposes `stamp`, `clear`, `serialize`, and `load`.
- Integrated painting into the engine: `src/engine/Engine.js` initializes `PaintModeManager`, exposes `setPaintMode`, `setPaintSetting`, `clearPaintLayers`, updates paint each tick, disables paint when switching modes/player, and persists paint into saved project JSON (`paint` field) and restores on load.
- Shader integration: added paint uniforms and samplers in `src/engine/terrain/terrainGLSL.js` and `src/engine/terrain/TerrainMaterial.js` so final height = procedural height + painted height offset and painted biome channels blend into `BiomeWeights` (non‑destructive override via `uPaint*` uniforms and `uPaintHeightTexture`/`uPaintBiomeTexture`).
- UI and UX: added a topbar `Paint Mode` button (`src/components/TopBar.jsx`) and a `PaintPanel` UI (`src/components/paint/PaintPanel.jsx`) to select tools (Raise, Lower, Smooth, Flatten, Set Height, Biome, Erase), adjust brush size/strength/falloff/targetHeight/opactiy, clear layers and exit.
- Styling and canvas behavior: added paint panel styles to `src/styles.css` and disabled touch gestures on the viewport to keep painting interactions focused (`touch-action: none` on `#viewport`).
- Performance / safety: painting operates on small DataTextures and updates only those textures (`needsUpdate`), uses the CPU GPU-backed height sampler to ray-project the brush to the analytic height field (no permanent procedural bake), and smooths/limits stamp frequency to avoid per-stroke full rebuilds.

### Testing
- `npm run build` — succeeded; production bundle built (assets produced, with code-splitting/size warning only). 
- `npm test -- --runInBand` — not run because the project has no `test` script (reported by `npm`), so no automated JS unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2abd63b4548324abfca77cdd72a5fa)