### PR TITLE
Add mobile touch controls and responsive layout

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.2",
+  "version": "0.5.5",
   "configurations": [
     {
       "name": "dev",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "terrain-studio",
-  "version": "0.5.2",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "terrain-studio",
   "private": true,
-  "version": "0.5.2",
+  "version": "0.5.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import TopBar from './components/TopBar.jsx';
 import LeftToolbar from './components/ui/LeftToolbar.jsx';
 import SideDrawer from './components/ui/SideDrawer.jsx';
 import BottomToolbar from './components/BottomToolbar.jsx';
+import WorldModeBar from './components/WorldModeBar.jsx';
 import StatusBar from './components/StatusBar.jsx';
 import InfiniteHUD from './components/InfiniteHUD.jsx';
 import MinimapOverlay from './components/MinimapOverlay.jsx';
@@ -37,7 +38,7 @@ export default function App() {
   const [gpu, setGpu] = useState('–');
 
   const [camMode, setCamMode] = useState('orbit');
-  const [helpVisible, setHelpVisible] = useState(true);
+  const [helpVisible, setHelpVisible] = useState(false);
   const [previewMode, setPreviewMode] = useState(false);
   const [activePanel, setActivePanel] = useState(null);
   const [paintState, setPaintState] = useState({ enabled: false });
@@ -353,6 +354,15 @@ export default function App() {
 
         <div className="viewport-area">
           <canvas id="viewport" ref={canvasRef} />
+
+          {!previewMode && (
+            <WorldModeBar
+              floating
+              worldMode={worldMode}
+              onSetWorldMode={selectWorldMode}
+              modeLocked={modeLocked}
+            />
+          )}
 
           <div id="help-card" className={helpVisible && studioLike ? '' : 'hidden'}>
             <div className="help-row"><span className="help-ic">🖐</span> Drag to pan</div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -356,7 +356,7 @@ export default function App() {
 
           <div id="help-card" className={helpVisible && studioLike ? '' : 'hidden'}>
             <div className="help-row"><span className="help-ic">🖐</span> Drag to pan</div>
-            <div className="help-row"><span className="help-ic">🖱</span> Scroll to zoom</div>
+            <div className="help-row"><span className="help-ic">🤏</span> Pinch to zoom • move two fingers to pan</div>
             <div className="help-row"><span className="help-ic">↻</span> Right-click + drag to orbit</div>
           </div>
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import BottomToolbar from './components/BottomToolbar.jsx';
 import WorldModeBar from './components/WorldModeBar.jsx';
 import StatusBar from './components/StatusBar.jsx';
 import InfiniteHUD from './components/InfiniteHUD.jsx';
+import TouchControls from './components/TouchControls.jsx';
 import MinimapOverlay from './components/MinimapOverlay.jsx';
 import PaintPanel from './components/paint/PaintPanel.jsx';
 import LoadingOverlay from './components/ui/LoadingOverlay.jsx';
@@ -327,7 +328,7 @@ export default function App() {
   };
 
   return (
-    <div id="app" className={`${previewMode ? 'preview-mode' : ''} ${fpsView ? 'infinite-mode' : ''}`}>
+    <div id="app" className={`${previewMode ? 'preview-mode' : ''} ${fpsView ? 'infinite-mode fps-explore-mode' : ''}${effectivePanel ? ' side-drawer-open' : ''}`}>
       <TopBar
         previewMode={previewMode}
         worldMode={worldMode}
@@ -354,15 +355,6 @@ export default function App() {
 
         <div className="viewport-area">
           <canvas id="viewport" ref={canvasRef} />
-
-          {!previewMode && (
-            <WorldModeBar
-              floating
-              worldMode={worldMode}
-              onSetWorldMode={selectWorldMode}
-              modeLocked={modeLocked}
-            />
-          )}
 
           <div id="help-card" className={helpVisible && studioLike ? '' : 'hidden'}>
             <div className="help-row"><span className="help-ic">🖐</span> Drag to pan</div>
@@ -400,29 +392,32 @@ export default function App() {
           )}
 
           {fpsView && (
-            <InfiniteHUD
-              stats={infiniteStats}
-              isPlanet={isPlanet}
-              onReturn={() => selectWorldMode('studio')}
-              playerMode={playerMode}
-              onPlayerMode={togglePlayerMode}
-              quality={qualityPreset}
-              onQualityChange={handleQualityChange}
-              timeOfDay={timeOfDay}
-              onTimeOfDay={handleTimeOfDay}
-              behindCameraCulling={behindCameraCulling}
-              onBehindCameraCulling={handleBehindCameraCulling}
-              planetPreset={params.planetPreset}
-              onPlanetPreset={(key) => engine().applyPlanetPresetByKey(key)}
-              onGeneratePalette={() => engine().generatePalette()}
-              onRandomPlanet={() => engine().randomizePlanetPreset()}
-              perf={perf}
-              gpu={gpu}
-              perfStats={stats}
-              onPerfPreset={(key) => engine().setPerfPreset(key)}
-              onPerfSetting={(key, value) => engine().setPerfSetting(key, value)}
-              onPerfReset={() => engine().resetPerfSettings()}
-            />
+            <>
+              <InfiniteHUD
+                stats={infiniteStats}
+                isPlanet={isPlanet}
+                onReturn={() => selectWorldMode('studio')}
+                playerMode={playerMode}
+                onPlayerMode={togglePlayerMode}
+                quality={qualityPreset}
+                onQualityChange={handleQualityChange}
+                timeOfDay={timeOfDay}
+                onTimeOfDay={handleTimeOfDay}
+                behindCameraCulling={behindCameraCulling}
+                onBehindCameraCulling={handleBehindCameraCulling}
+                planetPreset={params.planetPreset}
+                onPlanetPreset={(key) => engine().applyPlanetPresetByKey(key)}
+                onGeneratePalette={() => engine().generatePalette()}
+                onRandomPlanet={() => engine().randomizePlanetPreset()}
+                perf={perf}
+                gpu={gpu}
+                perfStats={stats}
+                onPerfPreset={(key) => engine().setPerfPreset(key)}
+                onPerfSetting={(key, value) => engine().setPerfSetting(key, value)}
+                onPerfReset={() => engine().resetPerfSettings()}
+              />
+              <TouchControls onInput={(input) => engine().setTouchInput(input)} />
+            </>
           )}
 
           {block && <LoadingOverlay task={block} />}
@@ -432,6 +427,15 @@ export default function App() {
           <SideDrawer activePanel={effectivePanel} ctx={ctx} onClose={() => setActivePanel(null)} />
         )}
       </div>
+
+      {!previewMode && (
+        <WorldModeBar
+          floating
+          worldMode={worldMode}
+          onSetWorldMode={selectWorldMode}
+          modeLocked={modeLocked}
+        />
+      )}
 
       <StatusBar
         status={status}

--- a/src/components/BottomToolbar.jsx
+++ b/src/components/BottomToolbar.jsx
@@ -5,35 +5,46 @@ export default function BottomToolbar({ camMode, onTopDown, onAngled, onResetCam
         type="button"
         className={`camera-bar-btn${camMode === 'topdown' ? ' active' : ''}`}
         onClick={onTopDown}
+        aria-label="Top-down view"
+        title="Top-down view"
       >
         <svg viewBox="0 0 16 16" fill="none">
           <rect x="3" y="3" width="10" height="10" rx="1.5" stroke="currentColor" strokeWidth="1.2" />
           <path d="M3 7h10M7 3v10" stroke="currentColor" strokeWidth="0.8" opacity=".6" />
         </svg>
-        Top-down
+        <span className="camera-bar-label">Top-down</span>
       </button>
       <button
         type="button"
         className={`camera-bar-btn${camMode !== 'topdown' ? ' active' : ''}`}
         onClick={onAngled}
+        aria-label="Angled view"
+        title="Angled view"
       >
         <svg viewBox="0 0 16 16" fill="none">
           <path d="M2 11 8 4l6 7z" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
           <path d="M2 11h12" stroke="currentColor" strokeWidth="1.2" />
         </svg>
-        Angled
+        <span className="camera-bar-label">Angled</span>
       </button>
-      <button type="button" className="camera-bar-btn" onClick={onResetCamera}>
+      <button
+        type="button"
+        className="camera-bar-btn"
+        onClick={onResetCamera}
+        aria-label="Reset camera"
+        title="Reset camera"
+      >
         <svg viewBox="0 0 16 16" fill="none">
           <circle cx="8" cy="8" r="5.5" stroke="currentColor" strokeWidth="1.2" />
           <circle cx="8" cy="8" r="1.6" fill="currentColor" />
         </svg>
-        Reset Camera
+        <span className="camera-bar-label">Reset Camera</span>
       </button>
       <button
         type="button"
         className={`camera-bar-btn${playerMode ? ' active' : ''}`}
         onClick={onTogglePlayer}
+        aria-label={playerMode ? 'Exit walk mode' : 'Walk mode'}
         title="Walk on the terrain: gravity, jumping, swimming (click viewport to lock mouse)"
       >
         <svg viewBox="0 0 16 16" fill="none">
@@ -41,7 +52,7 @@ export default function BottomToolbar({ camMode, onTopDown, onAngled, onResetCam
           <path d="M8 5v4M8 9l-2.5 4M8 9l2.5 4M5.5 6.6 8 6l2.5.6"
             stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
         </svg>
-        {playerMode ? 'Exit Walk' : 'Walk'}
+        <span className="camera-bar-label">{playerMode ? 'Exit Walk' : 'Walk'}</span>
       </button>
     </div>
   );

--- a/src/components/InfiniteHUD.jsx
+++ b/src/components/InfiniteHUD.jsx
@@ -18,6 +18,18 @@ const PLAYER_STATE_LABELS = {
   underwater: 'Underwater',
 };
 
+const DockBtn = ({ active, onClick, title, children }) => (
+  <button
+    type="button"
+    className={`fps-dock-btn camera-bar-btn${active ? ' active' : ''}`}
+    onClick={onClick}
+    title={title}
+    aria-pressed={active}
+  >
+    {children}
+  </button>
+);
+
 export default function InfiniteHUD({
   stats, onReturn, isPlanet,
   playerMode, onPlayerMode,
@@ -31,10 +43,10 @@ export default function InfiniteHUD({
   if (!stats) return null;
 
   const qualityKeys = getQualityKeys();
+  const togglePerf = () => setPerfOpen((v) => !v);
 
   return (
     <>
-      {/* Crosshair */}
       <div id="fps-crosshair">
         <svg width="24" height="24" viewBox="0 0 24 24">
           <circle cx="12" cy="12" r="2" fill="none" stroke="rgba(255,255,255,0.55)" strokeWidth="1.2" />
@@ -45,7 +57,6 @@ export default function InfiniteHUD({
         </svg>
       </div>
 
-      {/* Top-left info */}
       <div id="fps-info">
         <div className="fps-info-row">
           <span className="fps-info-label">POS</span>
@@ -78,9 +89,7 @@ export default function InfiniteHUD({
         )}
       </div>
 
-      {/* Top-right controls panel */}
       <div id="fps-settings-panel">
-        {/* Player physics toggle */}
         <div className="fps-setting-row">
           <span className="fps-setting-label">Walk mode</span>
           <button
@@ -91,8 +100,6 @@ export default function InfiniteHUD({
             title="Player physics: gravity, walking, jumping, swimming"
           />
         </div>
-
-        {/* Quality selector */}
         <div className="fps-setting-row">
           <span className="fps-setting-label">Quality</span>
           <select
@@ -109,8 +116,6 @@ export default function InfiniteHUD({
             {quality === 'custom' && <option value="custom">Custom</option>}
           </select>
         </div>
-
-        {/* Time of day slider */}
         <div className="fps-setting-row">
           <span className="fps-setting-label">Time</span>
           <span className="fps-setting-value">{formatTimeOfDay(timeOfDay)}</span>
@@ -126,8 +131,6 @@ export default function InfiniteHUD({
           style={{ '--fill': `${timeOfDay * 100}%` }}
           onChange={(e) => onTimeOfDay(parseFloat(e.target.value))}
         />
-
-        {/* Planet style (compact) */}
         <div className="fps-setting-row">
           <span className="fps-setting-label">Planet</span>
           <select
@@ -148,8 +151,6 @@ export default function InfiniteHUD({
             Random
           </button>
         </div>
-
-        {/* Behind-camera culling toggle */}
         <div className="fps-setting-row">
           <span className="fps-setting-label">Back culling</span>
           <button
@@ -161,7 +162,6 @@ export default function InfiniteHUD({
         </div>
       </div>
 
-      {/* Bottom center speed bar */}
       <div id="fps-speed-bar">
         <svg viewBox="0 0 16 16" width="14" height="14">
           <path d="M8 2v8M4 6l4-4 4 4" stroke="currentColor" fill="none" strokeWidth="1.3" strokeLinejoin="round" />
@@ -171,13 +171,23 @@ export default function InfiniteHUD({
         <span className="fps-speed-hint">Scroll to adjust</span>
       </div>
 
-      {/* Collapsible performance window (bottom) */}
+      {perf && (
+        <div className="fps-mobile-dock">
+          <DockBtn active={perfOpen} onClick={togglePerf} title="Performance">
+            <svg viewBox="0 0 16 16" fill="none" width="14" height="14" aria-hidden>
+              <path d="M2 12h12M4 9l2.5-4 2.5 3.2L13 3" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </DockBtn>
+          <span className="fps-dock-speed">{stats.speed} u/s</span>
+        </div>
+      )}
+
       {perf && (
         <div id="fps-perf-window" className={perfOpen ? 'open' : ''}>
           <button
             type="button"
-            className="fps-perf-header"
-            onClick={() => setPerfOpen((v) => !v)}
+            className="fps-perf-header fps-perf-header-desktop"
+            onClick={togglePerf}
             aria-expanded={perfOpen}
           >
             <svg viewBox="0 0 16 16" width="13" height="13" fill="none" aria-hidden>
@@ -202,7 +212,6 @@ export default function InfiniteHUD({
         </div>
       )}
 
-      {/* Controls hint */}
       <div id="fps-controls-hint">
         {playerMode ? (
           <>
@@ -224,15 +233,6 @@ export default function InfiniteHUD({
           </>
         )}
       </div>
-
-      {/* Return button */}
-      {/* <button id="fps-return-btn" onClick={onReturn} title="Return to Terrain Studio">
-        <svg viewBox="0 0 16 16" width="14" height="14">
-          <path d="M13.5 8a5.5 5.5 0 1 1-1.6-3.9" stroke="currentColor" fill="none" strokeWidth="1.3" />
-          <path d="M13.7 1.8v2.8h-2.8" stroke="currentColor" fill="none" strokeWidth="1.3" />
-        </svg>
-        Terrain Studio
-      </button> */}
     </>
   );
 }

--- a/src/components/MinimapOverlay.jsx
+++ b/src/components/MinimapOverlay.jsx
@@ -1,41 +1,59 @@
 import { useState } from 'react';
 
+const MapIcon = () => (
+  <svg viewBox="0 0 16 16" fill="none" width="14" height="14" aria-hidden>
+    <path d="M1 3l4.5-2v12L1 15V3zM5.5 1l5 2v12l-5-2V1zM10.5 3L15 1v12l-4.5 2V3z" stroke="currentColor" strokeWidth="1.2" />
+  </svg>
+);
+
 export default function MinimapOverlay({ boardSize, baseRef, overlayRef, drawerOpen = false }) {
-  const [collapsed, setCollapsed] = useState(false);
+  const [collapsed, setCollapsed] = useState(true);
 
   return (
     <div className={`minimap-overlay-container${collapsed ? ' collapsed' : ''}${drawerOpen ? ' drawer-open' : ''}`}>
-      <div className="minimap-overlay-header">
-        <span className="minimap-title">
-          <svg viewBox="0 0 16 16" fill="none" width="12" height="12" style={{ marginRight: '6px', color: 'var(--accent)' }}>
-            <path d="M1 3l4.5-2v12L1 15V3zM5.5 1l5 2v12l-5-2V1zM10.5 3L15 1v12l-4.5 2V3z" stroke="currentColor" strokeWidth="1.2" />
-          </svg>
-          MAP Preview
-        </span>
-        <button
-          type="button"
-          className="minimap-toggle-btn"
-          onClick={() => setCollapsed(!collapsed)}
-          title={collapsed ? "Expand Minimap" : "Collapse Minimap"}
-        >
-          {collapsed ? (
-            <svg viewBox="0 0 16 16" width="10" height="10" fill="none">
-              <path d="M4 10l4-4 4 4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
-            </svg>
-          ) : (
-            <svg viewBox="0 0 16 16" width="10" height="10" fill="none">
-              <path d="M4 6l4 4 4-4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
-            </svg>
-          )}
-        </button>
-      </div>
-      <div className="minimap-overlay-body">
-        <div className="minimap-wrap" data-tooltip="Minimap showing active terrain height contours and camera positions">
-          <canvas className="minimap-base" width="256" height="256" ref={baseRef} />
-          <canvas className="minimap-overlay" width="256" height="256" ref={overlayRef} />
+      <button
+        type="button"
+        className="minimap-fab"
+        onClick={() => setCollapsed(false)}
+        title="Show map preview"
+        aria-label="Show map preview"
+        aria-expanded={!collapsed}
+      >
+        <MapIcon />
+      </button>
+
+      <div className="minimap-panel">
+        <div className="minimap-overlay-header">
+          <span className="minimap-title">
+            <MapIcon />
+            <span className="minimap-title-text">MAP Preview</span>
+          </span>
+          <button
+            type="button"
+            className="minimap-toggle-btn"
+            onClick={() => setCollapsed((v) => !v)}
+            title={collapsed ? 'Expand minimap' : 'Collapse minimap'}
+            aria-label={collapsed ? 'Expand minimap' : 'Collapse minimap'}
+          >
+            {collapsed ? (
+              <svg viewBox="0 0 16 16" width="10" height="10" fill="none" aria-hidden>
+                <path d="M4 10l4-4 4 4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+              </svg>
+            ) : (
+              <svg viewBox="0 0 16 16" width="10" height="10" fill="none" aria-hidden>
+                <path d="M4 6l4 4 4-4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+              </svg>
+            )}
+          </button>
         </div>
-        <div className="minimap-caption" data-tooltip="Total boundary size of the generated world grid in units">
-          Board: {boardSize} × {boardSize} units
+        <div className="minimap-overlay-body">
+          <div className="minimap-wrap" data-tooltip="Minimap showing active terrain height contours and camera positions">
+            <canvas className="minimap-base" width="256" height="256" ref={baseRef} />
+            <canvas className="minimap-overlay" width="256" height="256" ref={overlayRef} />
+          </div>
+          <div className="minimap-caption" data-tooltip="Total boundary size of the generated world grid in units">
+            Board: {boardSize} × {boardSize} units
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef, useState } from 'react';
+import { useRef } from 'react';
 import { APP_NAME, APP_VERSION } from '../constants/app.js';
+import WorldModeBar from './WorldModeBar.jsx';
 
 const Icon = ({ d, viewBox = '0 0 16 16', fill }) => (
   <svg viewBox={viewBox}>
@@ -8,12 +9,6 @@ const Icon = ({ d, viewBox = '0 0 16 16', fill }) => (
       : <path d={d} stroke="currentColor" fill={fill ?? 'none'} strokeWidth="1.2" />}
   </svg>
 );
-
-const MODES = [
-  { id: 'studio', label: 'Tile' },
-  { id: 'infinite', label: 'Infinite World' },
-  { id: 'planet', label: 'Planet' },
-];
 
 export default function TopBar({
   previewMode, worldMode, onNew, onRandomize, onSave, onLoadJSON,
@@ -78,19 +73,7 @@ export default function TopBar({
         </button>
       </div>
 
-      <div className="tb-segment" role="group" aria-label="World mode">
-        {MODES.map((m) => (
-          <button
-            key={m.id}
-            className={`tb-mode${worldMode === m.id ? ' active' : ''}`}
-            onClick={() => onSetWorldMode(m.id)}
-            disabled={modeLocked}
-            aria-pressed={worldMode === m.id}
-          >
-            {m.label}
-          </button>
-        ))}
-      </div>
+      <WorldModeBar worldMode={worldMode} onSetWorldMode={onSetWorldMode} modeLocked={modeLocked} />
 
       <div className="tb-group tb-right">
         {loading && (

--- a/src/components/TouchControls.jsx
+++ b/src/components/TouchControls.jsx
@@ -1,0 +1,116 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+const RADIUS = 52;
+const DEAD = 0.12;
+
+function clampKnob(dx, dy, max) {
+  const len = Math.hypot(dx, dy);
+  if (len <= max) return { x: dx, y: dy };
+  const s = max / len;
+  return { x: dx * s, y: dy * s };
+}
+
+function norm(dx, dy, max) {
+  const nx = dx / max;
+  const ny = dy / max;
+  const len = Math.hypot(nx, ny);
+  if (len < DEAD) return { x: 0, y: 0 };
+  const s = Math.min(1, len);
+  return { x: (nx / len) * s, y: (ny / len) * s };
+}
+
+function useJoystick(onChange) {
+  const baseRef = useRef(null);
+  const knobRef = useRef(null);
+  const activeRef = useRef(null);
+
+  const reset = useCallback(() => {
+    activeRef.current = null;
+    if (knobRef.current) {
+      knobRef.current.style.transform = 'translate(-50%, -50%)';
+    }
+    onChange(0, 0);
+  }, [onChange]);
+
+  const onPointerDown = useCallback((e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    activeRef.current = e.pointerId;
+    baseRef.current?.setPointerCapture(e.pointerId);
+  }, []);
+
+  const onPointerMove = useCallback((e) => {
+    if (activeRef.current !== e.pointerId || !baseRef.current || !knobRef.current) return;
+    const rect = baseRef.current.getBoundingClientRect();
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+    const raw = clampKnob(e.clientX - cx, e.clientY - cy, RADIUS);
+    const n = norm(raw.x, raw.y, RADIUS);
+    knobRef.current.style.transform = `translate(calc(-50% + ${raw.x}px), calc(-50% + ${raw.y}px))`;
+    onChange(n.x, n.y);
+  }, [onChange]);
+
+  const onPointerUp = useCallback((e) => {
+    if (activeRef.current !== e.pointerId) return;
+    if (baseRef.current?.hasPointerCapture(e.pointerId)) {
+      baseRef.current.releasePointerCapture(e.pointerId);
+    }
+    reset();
+  }, [reset]);
+
+  useEffect(() => () => reset(), [reset]);
+
+  return { baseRef, knobRef, onPointerDown, onPointerMove, onPointerUp };
+}
+
+export default function TouchControls({ onInput }) {
+  const stateRef = useRef({ moveX: 0, moveY: 0, lookX: 0, lookY: 0 });
+
+  const sync = useCallback(() => {
+    onInput?.({ ...stateRef.current });
+  }, [onInput]);
+
+  const onMove = useCallback((x, y) => {
+    stateRef.current.moveX = x;
+    stateRef.current.moveY = -y;
+    sync();
+  }, [sync]);
+
+  const onLook = useCallback((x, y) => {
+    stateRef.current.lookX = x;
+    stateRef.current.lookY = y;
+    sync();
+  }, [sync]);
+
+  const move = useJoystick(onMove);
+  const look = useJoystick(onLook);
+
+  useEffect(() => () => onInput?.({ moveX: 0, moveY: 0, lookX: 0, lookY: 0 }), [onInput]);
+
+  return (
+    <div className="touch-controls">
+      <div
+        ref={move.baseRef}
+        className="touch-joystick touch-joystick-move"
+        onPointerDown={move.onPointerDown}
+        onPointerMove={move.onPointerMove}
+        onPointerUp={move.onPointerUp}
+        onPointerCancel={move.onPointerUp}
+      >
+        <div ref={move.knobRef} className="touch-joystick-knob" />
+        <span className="touch-joystick-label">Move</span>
+      </div>
+      <div
+        ref={look.baseRef}
+        className="touch-joystick touch-joystick-look"
+        onPointerDown={look.onPointerDown}
+        onPointerMove={look.onPointerMove}
+        onPointerUp={look.onPointerUp}
+        onPointerCancel={look.onPointerUp}
+      >
+        <div ref={look.knobRef} className="touch-joystick-knob" />
+        <span className="touch-joystick-label">Look</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/WorldModeBar.jsx
+++ b/src/components/WorldModeBar.jsx
@@ -1,0 +1,43 @@
+const MODES = [
+  { id: 'studio', label: 'Tile' },
+  { id: 'infinite', label: 'Infinite World' },
+  { id: 'planet', label: 'Planet' },
+];
+
+export default function WorldModeBar({ worldMode, onSetWorldMode, modeLocked, floating = false }) {
+  if (floating) {
+    return (
+      <div className="viewport-mode-bar" role="group" aria-label="World mode">
+        {MODES.map((m) => (
+          <button
+            key={m.id}
+            type="button"
+            className={`camera-bar-btn mode-bar-btn${worldMode === m.id ? ' active' : ''}`}
+            onClick={() => onSetWorldMode(m.id)}
+            disabled={modeLocked}
+            aria-pressed={worldMode === m.id}
+          >
+            {m.label}
+          </button>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="tb-segment" role="group" aria-label="World mode">
+      {MODES.map((m) => (
+        <button
+          key={m.id}
+          type="button"
+          className={`tb-mode${worldMode === m.id ? ' active' : ''}`}
+          onClick={() => onSetWorldMode(m.id)}
+          disabled={modeLocked}
+          aria-pressed={worldMode === m.id}
+        >
+          {m.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/constants/app.js
+++ b/src/constants/app.js
@@ -1,4 +1,4 @@
 // Single source of truth for the app version. Display it everywhere from here.
-export const APP_VERSION = '0.5.2';
+export const APP_VERSION = '0.5.5';
 export const APP_NAME = 'Procedural Terrains';
 export const GITHUB_REPO_URL = 'https://github.com/ZyFou/ProceduralTerrains';

--- a/src/engine/EditorControls.js
+++ b/src/engine/EditorControls.js
@@ -36,6 +36,8 @@ export class EditorControls {
     this.inputMode = 'all';        // 'all' or 'orbitOnly' while paint mode owns left drag
     this._interacted = false;
     this._drag = null;             // { button, x, y }
+    this._touches = new Map();      // active touch pointers for pan / pinch zoom
+    this._pinch = null;             // { x, y, dist, radius }
 
     domElement.addEventListener('pointerdown', (e) => this._onDown(e));
     domElement.addEventListener('pointermove', (e) => this._onMove(e));
@@ -94,6 +96,14 @@ export class EditorControls {
 
   _onDown(e) {
     if (!this.enabled) return;
+    if (e.pointerType === 'touch') {
+      if (this.inputMode === 'orbitOnly') return;
+      this._markInteract();
+      this._touches.set(e.pointerId, { x: e.clientX, y: e.clientY });
+      this._pinch = this._getPinchState();
+      this.dom.setPointerCapture(e.pointerId);
+      return;
+    }
     if (e.button !== 0 && e.button !== 2) return;
     if (this.inputMode === 'orbitOnly' && e.button !== 2) return;
     this._markInteract();
@@ -101,35 +111,69 @@ export class EditorControls {
     this.dom.setPointerCapture(e.pointerId);
   }
 
+  _panByPixels(dx, dy) {
+    // pan in the ground plane, screen-relative, scaled by zoom + FOV
+    const h = this.dom.clientHeight || 1;
+    const worldPerPx = (2 * this.radius * Math.tan(this.camera.fov * DEG / 2)) / h;
+    const sin = Math.sin(this.theta), cos = Math.cos(this.theta);
+    // screen right in world XZ
+    const rx = cos, rz = -sin;
+    // screen up projected onto ground (away from camera)
+    const fx = -sin, fz = -cos;
+    this.goalTarget.x += (-dx * rx + dy * fx) * worldPerPx;
+    this.goalTarget.z += (-dx * rz + dy * fz) * worldPerPx;
+    this._clampTarget();
+  }
+
+  _getPinchState() {
+    const pts = Array.from(this._touches.values());
+    if (pts.length < 2) return null;
+    const [a, b] = pts;
+    const dx = b.x - a.x, dy = b.y - a.y;
+    return { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2, dist: Math.hypot(dx, dy) || 1, radius: this.goalRadius };
+  }
+
   _onMove(e) {
+    if (e.pointerType === 'touch' && this._touches.has(e.pointerId)) {
+      const prevTouch = this._touches.get(e.pointerId);
+      this._touches.set(e.pointerId, { x: e.clientX, y: e.clientY });
+      const pts = Array.from(this._touches.values());
+      if (pts.length >= 2) {
+        const next = this._getPinchState();
+        if (this._pinch && next) {
+          this._panByPixels(next.x - this._pinch.x, next.y - this._pinch.y);
+          this.goalRadius = Math.min(Math.max(this._pinch.radius * (this._pinch.dist / next.dist), this.minRadius), this.maxRadius);
+          this._pinch.x = next.x;
+          this._pinch.y = next.y;
+        }
+        return;
+      }
+      if (pts.length === 1 && this._pinch === null && prevTouch) {
+        this._panByPixels(e.clientX - prevTouch.x, e.clientY - prevTouch.y);
+      }
+      return;
+    }
     if (!this._drag) return;
     const dx = e.clientX - this._drag.x;
     const dy = e.clientY - this._drag.y;
     this._drag.x = e.clientX;
     this._drag.y = e.clientY;
 
-    if (this._drag.button === 0) {
-      // pan in the ground plane, screen-relative, scaled by zoom + FOV
-      const h = this.dom.clientHeight || 1;
-      const worldPerPx = (2 * this.radius * Math.tan(this.camera.fov * DEG / 2)) / h;
-      const sin = Math.sin(this.theta), cos = Math.cos(this.theta);
-      // screen right in world XZ
-      const rx = cos, rz = -sin;
-      // screen up projected onto ground (away from camera)
-      const fx = -sin, fz = -cos;
-      this.goalTarget.x += (-dx * rx + dy * fx) * worldPerPx;
-      this.goalTarget.z += (-dx * rz + dy * fz) * worldPerPx;
-      this._clampTarget();
-    } else {
+    if (this._drag.button === 0) this._panByPixels(dx, dy);
+    else {
       // orbit
       this.goalTheta -= dx * 0.005;
-      if (this.mode !== 'topdown') {
-        this.goalPhi = Math.min(Math.max(this.goalPhi - dy * 0.004, this.minPhi), this.maxPhi);
-      }
+      if (this.mode !== 'topdown') this.goalPhi = Math.min(Math.max(this.goalPhi - dy * 0.004, this.minPhi), this.maxPhi);
     }
   }
 
   _onUp(e) {
+    if (e.pointerType === 'touch') {
+      this._touches.delete(e.pointerId);
+      this._pinch = this._getPinchState();
+      try { this.dom.releasePointerCapture(e.pointerId); } catch { /* already released */ }
+      return;
+    }
     if (this._drag) {
       this._drag = null;
       try { this.dom.releasePointerCapture(e.pointerId); } catch { /* already released */ }

--- a/src/engine/Engine.js
+++ b/src/engine/Engine.js
@@ -1038,6 +1038,11 @@ export class Engine {
     this.camera.updateProjectionMatrix();
   }
 
+  setTouchInput(input) {
+    if (this.fpsControls) this.fpsControls.setTouchInput(input);
+    if (this.player?.setTouchInput) this.player.setTouchInput(input);
+  }
+
   // ------------------------------------------------------------- player mode
 
   _getHeightSampler() {

--- a/src/engine/FPSControls.js
+++ b/src/engine/FPSControls.js
@@ -26,6 +26,8 @@ export class FPSControls {
 
     this._keys = new Set();
     this._locked = false;
+    this.touch = { moveX: 0, moveY: 0, lookX: 0, lookY: 0 };
+    this.touchActive = false;
 
     // When a PlayerController drives the body, FPSControls only applies
     // mouse-look orientation; movement keys are read by the controller.
@@ -67,6 +69,15 @@ export class FPSControls {
   }
 
   get isLocked() { return this._locked; }
+
+  setTouchInput({ moveX = 0, moveY = 0, lookX = 0, lookY = 0 } = {}) {
+    this.touch.moveX = moveX;
+    this.touch.moveY = moveY;
+    this.touch.lookX = lookX;
+    this.touch.lookY = lookY;
+    this.touchActive = Math.hypot(moveX, moveY) > 0.02
+      || Math.hypot(lookX, lookY) > 0.02;
+  }
 
   // ---- event handlers ----
 
@@ -110,38 +121,50 @@ export class FPSControls {
 
   // ---- update ----
 
+  _applyTouchLook(dt) {
+    const { lookX, lookY } = this.touch;
+    if (Math.abs(lookX) < 0.02 && Math.abs(lookY) < 0.02) return;
+    const rate = this.mouseSensitivity * 220 * (dt || 0.016);
+    this.yaw -= lookX * rate;
+    this.pitch -= lookY * rate;
+    this.pitch = Math.max(-PITCH_LIMIT, Math.min(PITCH_LIMIT, this.pitch));
+  }
+
   update(dt) {
+    this._applyTouchLook(dt);
+
     if (this.externalMove) {
-      // PlayerController moves the body — only apply look orientation here
       this._applyOrientation();
       return;
     }
-    if (!this._locked) {
-      // still apply camera orientation even when unlocked
+
+    const canMove = this._locked || this.touchActive;
+    if (!canMove) {
       this._applyOrientation();
       return;
     }
 
     const speed = this.moveSpeed * dt;
-
-    // forward/backward direction (horizontal, ignoring pitch)
     const fwdX = -Math.sin(this.yaw);
     const fwdZ = -Math.cos(this.yaw);
-    // strafe direction
     const rightX = Math.cos(this.yaw);
     const rightZ = -Math.sin(this.yaw);
 
     let dx = 0, dy = 0, dz = 0;
 
-    // ZQSD layout
-    if (this._keys.has('KeyW') || this._keys.has('KeyZ')) { dx += fwdX; dz += fwdZ; }  // forward
-    if (this._keys.has('KeyS'))                           { dx -= fwdX; dz -= fwdZ; }  // backward
-    if (this._keys.has('KeyA') || this._keys.has('KeyQ')) { dx -= rightX; dz -= rightZ; } // strafe left
-    if (this._keys.has('KeyD'))                           { dx += rightX; dz += rightZ; } // strafe right
-    if (this._keys.has('Space'))                          { dy += 1; }  // ascend
-    if (this._keys.has('ShiftLeft') || this._keys.has('ShiftRight')) { dy -= 1; } // descend
+    if (this._keys.has('KeyW') || this._keys.has('KeyZ')) { dx += fwdX; dz += fwdZ; }
+    if (this._keys.has('KeyS')) { dx -= fwdX; dz -= fwdZ; }
+    if (this._keys.has('KeyA') || this._keys.has('KeyQ')) { dx -= rightX; dz -= rightZ; }
+    if (this._keys.has('KeyD')) { dx += rightX; dz += rightZ; }
+    if (this._keys.has('Space')) { dy += 1; }
+    if (this._keys.has('ShiftLeft') || this._keys.has('ShiftRight')) { dy -= 1; }
 
-    // normalize horizontal movement so diagonal isn't faster
+    if (this.touchActive) {
+      const { moveX, moveY } = this.touch;
+      dx += fwdX * moveY + rightX * moveX;
+      dz += fwdZ * moveY + rightZ * moveX;
+    }
+
     const hLen = Math.hypot(dx, dz);
     if (hLen > 1e-6) {
       dx = dx / hLen * speed;

--- a/src/engine/PlanetOrbitControls.js
+++ b/src/engine/PlanetOrbitControls.js
@@ -27,6 +27,8 @@ export class PlanetOrbitControls {
     this.onFirstInteract = null;
     this._interacted = false;
     this._drag = null;
+    this._touches = new Map();
+    this._pinch = null;
 
     this._onDown = this._onDown.bind(this);
     this._onMove = this._onMove.bind(this);
@@ -70,21 +72,61 @@ export class PlanetOrbitControls {
   _onDown(e) {
     if (!this.enabled) return;
     this._markInteract();
-    this._drag = { x: e.clientX, y: e.clientY };
+    if (e.pointerType === 'touch') {
+      this._touches.set(e.pointerId, { x: e.clientX, y: e.clientY });
+      this._pinch = this._getPinchState();
+    } else {
+      this._drag = { x: e.clientX, y: e.clientY };
+    }
     this.dom.setPointerCapture(e.pointerId);
   }
 
+  _orbitByPixels(dx, dy) {
+    this.goalTheta -= dx * 0.005;
+    this.goalPhi = Math.min(Math.max(this.goalPhi - dy * 0.004, this.minPhi), this.maxPhi);
+  }
+
+  _getPinchState() {
+    const pts = Array.from(this._touches.values());
+    if (pts.length < 2) return null;
+    const [a, b] = pts;
+    const dx = b.x - a.x, dy = b.y - a.y;
+    return { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2, dist: Math.hypot(dx, dy) || 1, zoom: this.goalDist };
+  }
+
   _onMove(e) {
+    if (e.pointerType === 'touch' && this._touches.has(e.pointerId)) {
+      const prev = this._touches.get(e.pointerId);
+      this._touches.set(e.pointerId, { x: e.clientX, y: e.clientY });
+      const pts = Array.from(this._touches.values());
+      if (pts.length >= 2) {
+        const next = this._getPinchState();
+        if (this._pinch && next) {
+          this._orbitByPixels(next.x - this._pinch.x, next.y - this._pinch.y);
+          this.goalDist = Math.min(Math.max(this._pinch.zoom * (this._pinch.dist / next.dist), this.minDist), this.maxDist);
+          this._pinch.x = next.x;
+          this._pinch.y = next.y;
+        }
+        return;
+      }
+      if (pts.length === 1 && this._pinch === null && prev) this._orbitByPixels(e.clientX - prev.x, e.clientY - prev.y);
+      return;
+    }
     if (!this._drag) return;
     const dx = e.clientX - this._drag.x;
     const dy = e.clientY - this._drag.y;
     this._drag.x = e.clientX;
     this._drag.y = e.clientY;
-    this.goalTheta -= dx * 0.005;
-    this.goalPhi = Math.min(Math.max(this.goalPhi - dy * 0.004, this.minPhi), this.maxPhi);
+    this._orbitByPixels(dx, dy);
   }
 
   _onUp(e) {
+    if (e.pointerType === 'touch') {
+      this._touches.delete(e.pointerId);
+      this._pinch = this._getPinchState();
+      try { this.dom.releasePointerCapture(e.pointerId); } catch { /* ok */ }
+      return;
+    }
     if (this._drag) {
       this._drag = null;
       try { this.dom.releasePointerCapture(e.pointerId); } catch { /* ok */ }

--- a/src/engine/player/PlanetController.js
+++ b/src/engine/player/PlanetController.js
@@ -60,6 +60,8 @@ export class PlanetController {
 
     this._keys = new Set();
     this._locked = false;
+    this.touch = { moveX: 0, moveY: 0, lookX: 0, lookY: 0 };
+    this.touchActive = false;
     this.mouseSensitivity = 0.0018;
 
     this._onClick = () => { if (!this._locked) this.dom.requestPointerLock(); };
@@ -102,6 +104,15 @@ export class PlanetController {
 
   get isLocked() { return this._locked; }
   get keys() { return this._keys; }
+
+  setTouchInput({ moveX = 0, moveY = 0, lookX = 0, lookY = 0 } = {}) {
+    this.touch.moveX = moveX;
+    this.touch.moveY = moveY;
+    this.touch.lookX = lookX;
+    this.touch.lookY = lookY;
+    this.touchActive = Math.hypot(moveX, moveY) > 0.02
+      || Math.hypot(lookX, lookY) > 0.02;
+  }
 
   /**
    * Facet-aware ground radius along a (near-unit) direction. The planet mesh is
@@ -160,9 +171,22 @@ export class PlanetController {
     this.pitch = Math.max(-PITCH_LIMIT, Math.min(PITCH_LIMIT, this.pitch));
   }
 
+  _applyTouchLook(dt) {
+    const { lookX, lookY } = this.touch;
+    if (Math.abs(lookX) < 0.02 && Math.abs(lookY) < 0.02) return;
+    const rate = this.mouseSensitivity * 220 * (dt || 0.016);
+    this.up.copy(this.pos).normalize();
+    this._q.setFromAxisAngle(this.up, -lookX * rate);
+    this.forward.applyQuaternion(this._q).normalize();
+    this.pitch -= lookY * rate;
+    this.pitch = Math.max(-PITCH_LIMIT, Math.min(PITCH_LIMIT, this.pitch));
+  }
+
   update(dt) {
+    this._applyTouchLook(dt);
     const cfg = this.cfg;
     const keys = this._keys;
+    const canInput = this._locked || this.touchActive;
 
     // local frame
     this.up.copy(this.pos).normalize();
@@ -174,17 +198,23 @@ export class PlanetController {
 
     // --- wish direction (tangent) ---
     let wx = 0, wy = 0, wz = 0;
-    if (this._locked) {
+    if (canInput) {
       if (keys.has('KeyW') || keys.has('KeyZ')) { wx += this.forward.x; wy += this.forward.y; wz += this.forward.z; }
       if (keys.has('KeyS')) { wx -= this.forward.x; wy -= this.forward.y; wz -= this.forward.z; }
       if (keys.has('KeyD')) { wx += right.x; wy += right.y; wz += right.z; }
       if (keys.has('KeyA') || keys.has('KeyQ')) { wx -= right.x; wy -= right.y; wz -= right.z; }
+      if (this.touchActive) {
+        const { moveX, moveY } = this.touch;
+        wx += this.forward.x * moveY + right.x * moveX;
+        wy += this.forward.y * moveY + right.y * moveX;
+        wz += this.forward.z * moveY + right.z * moveX;
+      }
     }
     const wl = Math.hypot(wx, wy, wz);
     if (wl > 1e-6) { wx /= wl; wy /= wl; wz /= wl; }
 
-    const running = this._locked && (keys.has('ShiftLeft') || keys.has('ShiftRight'));
-    const jumpKey = this._locked && keys.has('Space');
+    const running = canInput && (keys.has('ShiftLeft') || keys.has('ShiftRight'));
+    const jumpKey = canInput && keys.has('Space');
     if (jumpKey && !this._jumpHeld) this._jumpBuf = cfg.jumpBufferTime;
     else this._jumpBuf = Math.max(0, this._jumpBuf - dt);
     this._jumpHeld = jumpKey;

--- a/src/engine/player/PlayerController.js
+++ b/src/engine/player/PlayerController.js
@@ -87,6 +87,7 @@ export class PlayerController {
     const cfg = this.cfg;
     const keys = this.controls.keys;
     const locked = this.controls.isLocked;
+    const touch = this.controls.touchActive;
 
     // --- input -> wish direction (camera-yaw relative, horizontal) ---
     const yaw = this.controls.yaw;
@@ -94,18 +95,23 @@ export class PlayerController {
     const rightX = Math.cos(yaw), rightZ = -Math.sin(yaw);
 
     let ix = 0, iz = 0;
-    if (locked) {
+    if (locked || touch) {
       if (keys.has('KeyW') || keys.has('KeyZ')) { ix += fwdX; iz += fwdZ; }
       if (keys.has('KeyS')) { ix -= fwdX; iz -= fwdZ; }
       if (keys.has('KeyA') || keys.has('KeyQ')) { ix -= rightX; iz -= rightZ; }
       if (keys.has('KeyD')) { ix += rightX; iz += rightZ; }
+      if (touch) {
+        const t = this.controls.touch;
+        ix += fwdX * t.moveY + rightX * t.moveX;
+        iz += fwdZ * t.moveY + rightZ * t.moveX;
+      }
     }
     const iLen = Math.hypot(ix, iz);
     if (iLen > 1e-6) { ix /= iLen; iz /= iLen; }
 
-    const running = locked && (keys.has('ShiftLeft') || keys.has('ShiftRight'));
-    const jumpKey = locked && keys.has('Space');
-    const downKey = locked && (keys.has('ControlLeft') || keys.has('KeyC'));
+    const running = (locked || touch) && (keys.has('ShiftLeft') || keys.has('ShiftRight'));
+    const jumpKey = (locked || touch) && keys.has('Space');
+    const downKey = (locked || touch) && (keys.has('ControlLeft') || keys.has('KeyC'));
 
     // jump buffering (so a press just before landing still jumps)
     if (jumpKey && !this._jumpHeld) this._jumpBuffer = cfg.jumpBufferTime;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1079,6 +1079,7 @@ input[type="color"].palette-color-input {
   transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
 }
 .camera-bar-btn svg { width: 14px; height: 14px; }
+.camera-bar-btn .camera-bar-label { white-space: nowrap; }
 .camera-bar-btn:hover {
   background: var(--bg-control);
   color: var(--text-main);
@@ -1555,7 +1556,8 @@ input[type="color"].palette-color-input {
 #app.preview-mode .left-toolbar,
 #app.preview-mode .side-drawer,
 #app.preview-mode #help-card,
-#app.preview-mode .viewport-camera-bar { display: none; }
+#app.preview-mode .viewport-camera-bar,
+#app.preview-mode .viewport-mode-bar { display: none; }
 
 /* ============ INFINITE WORLD MODE ============ */
 .infinite-mode .left-toolbar,
@@ -2019,6 +2021,53 @@ input[type="color"].palette-color-input {
 .minimap-overlay-container.collapsed .minimap-overlay-header {
   border-bottom: none;
 }
+.minimap-fab {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+.minimap-fab:hover {
+  background: var(--bg-control);
+  color: var(--text-main);
+}
+.minimap-panel { display: contents; }
+
+/* Floating world-mode switcher (mobile canvas overlay) */
+.viewport-mode-bar {
+  display: none;
+  position: absolute;
+  top: calc(10px + env(safe-area-inset-top));
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 22;
+  max-width: calc(100vw - 20px);
+  gap: 2px;
+  padding: 4px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  box-shadow: var(--shadow-panel);
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+}
+.viewport-mode-bar::-webkit-scrollbar { display: none; }
+.mode-bar-btn {
+  flex: 0 0 auto;
+  white-space: nowrap;
+  font-size: 11px;
+  font-weight: 600;
+}
 
 /* ---- player physics state badge (status bar + infinite HUD) ---- */
 .player-state {
@@ -2369,45 +2418,127 @@ input[type="color"].palette-color-input {
 
   #topbar {
     height: auto;
-    min-height: 48px;
+    min-height: 40px;
     flex: 0 0 auto;
     flex-wrap: nowrap;
-    gap: 8px;
-    padding: 6px max(8px, env(safe-area-inset-right)) 6px max(8px, env(safe-area-inset-left));
+    gap: 4px;
+    padding: 4px max(6px, env(safe-area-inset-right)) 4px max(6px, env(safe-area-inset-left));
     overflow-x: auto;
     overflow-y: hidden;
     scrollbar-width: none;
     -webkit-overflow-scrolling: touch;
+    touch-action: pan-x;
   }
   #topbar::-webkit-scrollbar { display: none; }
-  .tb-brand { margin-right: 0; flex: 0 0 auto; }
-  .app-name { font-size: 12px; letter-spacing: 0.8px; }
+  .tb-brand { margin-right: 0; flex: 0 0 auto; padding-right: 2px; }
+  .tb-brand .logo { width: 18px; height: 18px; }
+  .app-name { display: none; }
   .app-version { display: none; }
-  .tb-group, .tb-segment { flex: 0 0 auto; }
-  .tb-btn, .tb-mode { min-height: 36px; }
-  .tb-btn { padding: 0 10px; }
+  .tb-group, .tb-segment { flex: 0 0 auto; gap: 2px; }
+  .tb-right { margin-left: 0; }
+  #topbar .tb-segment { display: none; }
+  .viewport-mode-bar { display: flex; }
+  .tb-btn {
+    width: 34px;
+    height: 34px;
+    min-height: 34px;
+    padding: 0;
+    justify-content: center;
+    gap: 0;
+    flex-shrink: 0;
+  }
+  .tb-btn svg { width: 15px; height: 15px; }
+  .tb-mode { min-height: 32px; padding: 0 10px; font-size: 11px; }
   .tb-actions .tb-text, .tb-right .tb-text { display: none; }
+  .tb-loading { height: 34px; padding: 0 8px; }
+  .tb-loading .tb-text { display: none; }
 
-  .app-shell { flex-direction: column; }
+  .app-shell { flex-direction: column; min-width: 0; }
   .left-toolbar {
     order: 2;
     width: 100%;
+    max-width: 100%;
+    min-width: 0;
     flex: 0 0 auto;
     min-height: 58px;
     max-height: 74px;
     flex-direction: row;
+    flex-wrap: nowrap;
     padding: 6px max(8px, env(safe-area-inset-right)) calc(6px + env(safe-area-inset-bottom)) max(8px, env(safe-area-inset-left));
     border-right: 0;
     border-top: 1px solid var(--border-subtle);
-    overflow-x: auto;
+    overflow-x: scroll;
     overflow-y: hidden;
     scrollbar-width: none;
     -webkit-overflow-scrolling: touch;
+    touch-action: pan-x;
+    overscroll-behavior-x: contain;
+    position: relative;
+    z-index: 16;
   }
   .left-toolbar::-webkit-scrollbar { display: none; }
   .toolbar-btn { flex: 0 0 54px; height: 46px; min-width: 54px; }
   .toolbar-btn-label { display: block; font-size: 8.5px; }
   .viewport-area { order: 1; min-height: 0; }
+
+  .minimap-overlay-container {
+    top: auto;
+    left: max(10px, env(safe-area-inset-left));
+    right: auto;
+    bottom: calc(12px + env(safe-area-inset-bottom));
+    width: auto;
+    background: var(--bg-panel);
+    border: 1px solid var(--border-subtle);
+    border-radius: 999px;
+    box-shadow: var(--shadow-panel);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    z-index: 11;
+  }
+  .minimap-overlay-container.collapsed {
+    width: auto;
+    padding: 0;
+    overflow: visible;
+  }
+  .minimap-overlay-container.collapsed .minimap-fab { display: flex; }
+  .minimap-overlay-container.collapsed .minimap-panel { display: none; }
+  .minimap-overlay-container:not(.collapsed) .minimap-fab { display: none; }
+  .minimap-overlay-container:not(.collapsed) .minimap-panel {
+    display: block;
+    width: 100%;
+  }
+  .minimap-overlay-container:not(.collapsed) {
+    width: 128px;
+    border-radius: 12px;
+    bottom: calc(12px + env(safe-area-inset-bottom));
+  }
+  .minimap-overlay-container.drawer-open {
+    right: auto;
+    left: max(10px, env(safe-area-inset-left));
+    opacity: 0;
+    pointer-events: none;
+  }
+  .minimap-overlay-header {
+    padding: 5px 8px;
+    background: transparent;
+  }
+  .minimap-overlay-container:not(.collapsed) .minimap-overlay-header {
+    border-bottom: 1px solid var(--border-subtle);
+  }
+  .minimap-title {
+    font-size: 9px;
+    letter-spacing: 0.8px;
+    gap: 5px;
+  }
+  .minimap-title-text { display: none; }
+  .minimap-overlay-body { padding: 6px; gap: 4px; }
+  .minimap-wrap { border-radius: 6px; }
+  .minimap-caption { font-size: 8px; margin-top: 0; text-align: center; }
+  .viewport-mode-bar .mode-bar-btn {
+    height: 32px;
+    padding: 0 11px;
+    font-size: 10.5px;
+  }
 
   .side-drawer {
     top: 0;
@@ -2435,10 +2566,22 @@ input[type="color"].palette-color-input {
   .viewport-camera-bar {
     bottom: calc(12px + env(safe-area-inset-bottom));
     max-width: calc(100vw - 20px);
-    overflow-x: auto;
+    flex-wrap: nowrap;
+    overflow-x: scroll;
+    overflow-y: hidden;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+    touch-action: pan-x;
+    overscroll-behavior-x: contain;
     border-radius: 16px;
   }
-  .camera-bar-btn { padding: 0 10px; }
+  .viewport-camera-bar::-webkit-scrollbar { display: none; }
+  .camera-bar-btn {
+    flex: 0 0 auto;
+    padding: 0 10px;
+    gap: 0;
+  }
+  .camera-bar-btn .camera-bar-label { display: none; }
 
   #statusbar {
     height: auto;
@@ -2468,11 +2611,12 @@ input[type="color"].palette-color-input {
   #statusbar { display: none; }
   .side-drawer { bottom: 58px; }
   .viewport-camera-bar { bottom: 72px; }
+  .minimap-overlay-container { bottom: 72px; }
+  .minimap-overlay-container:not(.collapsed) { bottom: 72px; }
   #help-card { max-width: 360px; right: auto; }
 }
 
 @media (max-width: 420px) {
-  .tb-segment { min-width: max-content; }
-  .tb-mode { padding: 0 9px; }
+  .viewport-mode-bar .mode-bar-btn { padding: 0 9px; font-size: 10px; }
   .toolbar-btn { flex-basis: 50px; min-width: 50px; }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -53,7 +53,7 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
-#app { display: flex; flex-direction: column; height: 100vh; }
+#app { display: flex; flex-direction: column; height: 100vh; position: relative; }
 
 /* ============ TOP BAR ============ */
 #topbar {
@@ -252,7 +252,7 @@ body {
   opacity: 0;
   pointer-events: none;
   transition: transform 0.2s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.2s ease;
-  z-index: 18;
+  z-index: 12;
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -1579,7 +1579,7 @@ input[type="color"].palette-color-input {
   position: absolute;
   top: 18px;
   left: 18px;
-  z-index: 15;
+  z-index: 12;
   background: var(--bg-panel);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-md);
@@ -1689,7 +1689,7 @@ input[type="color"].palette-color-input {
   position: absolute;
   top: 18px;
   right: 18px;
-  z-index: 15;
+  z-index: 12;
   display: none;
   background: var(--bg-panel);
   border: 1px solid var(--border-subtle);
@@ -1796,7 +1796,7 @@ input[type="color"].palette-color-input {
   position: absolute;
   right: 18px;
   bottom: 18px;
-  z-index: 16;
+  z-index: 12;
   display: none;
   flex-direction: column;
   width: 320px;
@@ -1835,6 +1835,88 @@ input[type="color"].palette-color-input {
   padding: 12px;
   max-height: min(60vh, 520px);
   overflow-y: auto;
+}
+
+/* Infinite mode mobile dock + touch controls */
+.fps-mobile-dock {
+  display: none;
+  position: absolute;
+  bottom: calc(12px + env(safe-area-inset-bottom));
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 14;
+  align-items: center;
+  gap: 2px;
+  padding: 4px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  box-shadow: var(--shadow-panel);
+}
+.fps-dock-btn {
+  width: 40px;
+  height: 40px;
+  padding: 0 !important;
+  justify-content: center;
+  gap: 0 !important;
+}
+.fps-dock-speed {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  padding: 0 10px 0 4px;
+  white-space: nowrap;
+}
+
+.touch-controls {
+  display: none;
+  position: absolute;
+  inset: 0;
+  z-index: 13;
+  pointer-events: none;
+}
+.touch-joystick {
+  position: absolute;
+  width: 118px;
+  height: 118px;
+  pointer-events: auto;
+  touch-action: none;
+  border-radius: 50%;
+  background: rgba(13, 13, 13, 0.42);
+  border: 1px solid var(--border-subtle);
+  box-shadow: var(--shadow-panel);
+}
+.touch-joystick-move {
+  left: max(12px, env(safe-area-inset-left));
+  bottom: calc(58px + env(safe-area-inset-bottom));
+}
+.touch-joystick-look {
+  right: max(12px, env(safe-area-inset-right));
+  bottom: calc(58px + env(safe-area-inset-bottom));
+}
+.touch-joystick-knob {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: var(--accent-bg);
+  border: 1px solid var(--border-active);
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+}
+.touch-joystick-label {
+  position: absolute;
+  bottom: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 8.5px;
+  font-weight: 700;
+  letter-spacing: 0.6px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  pointer-events: none;
 }
 
 .sb-quality {
@@ -2044,11 +2126,12 @@ input[type="color"].palette-color-input {
 /* Floating world-mode switcher (mobile canvas overlay) */
 .viewport-mode-bar {
   display: none;
-  position: absolute;
-  top: calc(10px + env(safe-area-inset-top));
+  position: fixed;
+  top: calc(54px + env(safe-area-inset-top));
   left: 50%;
   transform: translateX(-50%);
-  z-index: 22;
+  z-index: 28;
+  pointer-events: auto;
   max-width: calc(100vw - 20px);
   gap: 2px;
   padding: 4px;
@@ -2435,7 +2518,7 @@ input[type="color"].palette-color-input {
   .app-name { display: none; }
   .app-version { display: none; }
   .tb-group, .tb-segment { flex: 0 0 auto; gap: 2px; }
-  .tb-right { margin-left: 0; }
+  .tb-right { margin-left: auto; flex-shrink: 0; }
   #topbar .tb-segment { display: none; }
   .viewport-mode-bar { display: flex; }
   .tb-btn {
@@ -2540,14 +2623,44 @@ input[type="color"].palette-color-input {
     font-size: 10.5px;
   }
 
+  /* Infinite world mobile — perf dock only; hide stats/settings panels */
+  .fps-explore-mode .touch-controls { display: block; }
+  .fps-explore-mode #fps-info,
+  .fps-explore-mode #fps-settings-panel {
+    display: none !important;
+  }
+  .fps-explore-mode .fps-mobile-dock { display: flex; }
+  .fps-explore-mode #fps-perf-window {
+    display: none;
+  }
+  .fps-explore-mode #fps-perf-window.open {
+    display: flex;
+    left: max(10px, env(safe-area-inset-left));
+    right: max(10px, env(safe-area-inset-right));
+    bottom: calc(58px + env(safe-area-inset-bottom));
+    width: auto;
+    max-width: none;
+    border-radius: 12px;
+  }
+  .fps-explore-mode #fps-speed-bar { display: none !important; }
+  .fps-explore-mode #fps-controls-hint { display: none !important; }
+  .fps-explore-mode .fps-perf-header-desktop { display: none; }
+
   .side-drawer {
     top: 0;
     right: 0;
     bottom: 0;
     width: min(430px, 100vw);
     max-width: 100vw;
+    z-index: 20;
   }
-  .side-panel-header { padding: 12px 14px 10px; }
+  #app.side-drawer-open .viewport-mode-bar {
+    display: none !important;
+  }
+  .side-panel-header {
+    padding: 12px 14px 10px;
+    padding-top: max(12px, env(safe-area-inset-top));
+  }
   .side-panel-content { padding: 10px 14px calc(18px + env(safe-area-inset-bottom)); }
   .side-panel-close, .panel-tab, .action-btn, .camera-bar-btn { min-height: 40px; }
   .row input[type="number"], .row input[type="text"], .row select, .ctl-val { min-height: 34px; }
@@ -2609,10 +2722,14 @@ input[type="color"].palette-color-input {
   }
   .viewport-area { height: 100%; }
   #statusbar { display: none; }
-  .side-drawer { bottom: 58px; }
+  .side-drawer { bottom: 58px; z-index: 20; }
   .viewport-camera-bar { bottom: 72px; }
   .minimap-overlay-container { bottom: 72px; }
   .minimap-overlay-container:not(.collapsed) { bottom: 72px; }
+  .touch-joystick-move,
+  .touch-joystick-look { bottom: calc(72px + env(safe-area-inset-bottom)); }
+  .fps-mobile-dock { bottom: calc(12px + env(safe-area-inset-bottom)); }
+  .fps-explore-mode #fps-perf-window.open { bottom: calc(58px + env(safe-area-inset-bottom)); }
   #help-card { max-width: 360px; right: auto; }
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -2360,3 +2360,119 @@ input[type="color"].palette-color-input {
   font-style: italic;
 }
 
+
+/* ============ MOBILE / TOUCH LAYOUT ============ */
+@media (hover: none), (pointer: coarse), (max-width: 820px) {
+  html, body, #root, #app { height: 100%; width: 100%; }
+  body { -webkit-text-size-adjust: 100%; overscroll-behavior: none; }
+  button, input, select { font-size: 16px; }
+
+  #topbar {
+    height: auto;
+    min-height: 48px;
+    flex: 0 0 auto;
+    flex-wrap: nowrap;
+    gap: 8px;
+    padding: 6px max(8px, env(safe-area-inset-right)) 6px max(8px, env(safe-area-inset-left));
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+  }
+  #topbar::-webkit-scrollbar { display: none; }
+  .tb-brand { margin-right: 0; flex: 0 0 auto; }
+  .app-name { font-size: 12px; letter-spacing: 0.8px; }
+  .app-version { display: none; }
+  .tb-group, .tb-segment { flex: 0 0 auto; }
+  .tb-btn, .tb-mode { min-height: 36px; }
+  .tb-btn { padding: 0 10px; }
+  .tb-actions .tb-text, .tb-right .tb-text { display: none; }
+
+  .app-shell { flex-direction: column; }
+  .left-toolbar {
+    order: 2;
+    width: 100%;
+    flex: 0 0 auto;
+    min-height: 58px;
+    max-height: 74px;
+    flex-direction: row;
+    padding: 6px max(8px, env(safe-area-inset-right)) calc(6px + env(safe-area-inset-bottom)) max(8px, env(safe-area-inset-left));
+    border-right: 0;
+    border-top: 1px solid var(--border-subtle);
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+  }
+  .left-toolbar::-webkit-scrollbar { display: none; }
+  .toolbar-btn { flex: 0 0 54px; height: 46px; min-width: 54px; }
+  .toolbar-btn-label { display: block; font-size: 8.5px; }
+  .viewport-area { order: 1; min-height: 0; }
+
+  .side-drawer {
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: min(430px, 100vw);
+    max-width: 100vw;
+  }
+  .side-panel-header { padding: 12px 14px 10px; }
+  .side-panel-content { padding: 10px 14px calc(18px + env(safe-area-inset-bottom)); }
+  .side-panel-close, .panel-tab, .action-btn, .camera-bar-btn { min-height: 40px; }
+  .row input[type="number"], .row input[type="text"], .row select, .ctl-val { min-height: 34px; }
+  .slider-input { height: 30px; }
+  .slider-track-wrap { height: 30px; }
+
+  #help-card {
+    top: 10px;
+    left: 10px;
+    right: 10px;
+    max-width: calc(100vw - 20px);
+    padding: 10px 12px;
+    gap: 7px;
+  }
+  .help-row { font-size: 11.5px; }
+  .viewport-camera-bar {
+    bottom: calc(12px + env(safe-area-inset-bottom));
+    max-width: calc(100vw - 20px);
+    overflow-x: auto;
+    border-radius: 16px;
+  }
+  .camera-bar-btn { padding: 0 10px; }
+
+  #statusbar {
+    height: auto;
+    min-height: 24px;
+    flex: 0 0 auto;
+    gap: 8px;
+    padding: 4px max(8px, env(safe-area-inset-right)) 4px max(8px, env(safe-area-inset-left));
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  #statusbar::-webkit-scrollbar { display: none; }
+  .sb-group { flex: 0 0 auto; gap: 8px; }
+}
+
+@media (hover: none) and (pointer: coarse) and (orientation: landscape) and (max-height: 520px) {
+  #topbar { min-height: 42px; padding-top: 3px; padding-bottom: 3px; }
+  .tb-btn, .tb-mode { min-height: 32px; height: 32px; }
+  .left-toolbar {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 16;
+    background: rgba(13, 13, 13, 0.94);
+  }
+  .viewport-area { height: 100%; }
+  #statusbar { display: none; }
+  .side-drawer { bottom: 58px; }
+  .viewport-camera-bar { bottom: 72px; }
+  #help-card { max-width: 360px; right: auto; }
+}
+
+@media (max-width: 420px) {
+  .tb-segment { min-width: max-content; }
+  .tb-mode { padding: 0 9px; }
+  .toolbar-btn { flex-basis: 50px; min-width: 50px; }
+}


### PR DESCRIPTION
### Motivation
- Provide a usable mobile interface by adding touch gestures (one-finger pan, two-finger pinch-zoom/midpoint-move) for camera controls. 
- Ensure the UI and all control panels remain accessible and readable in portrait and landscape on touch devices.

### Description
- Implemented touch handling and pinch/translate logic in editor camera controls (`src/engine/EditorControls.js`) including `_touches`, `_pinch`, `_panByPixels`, and `_getPinchState` to support one-finger pan and two-finger pinch zoom with midpoint movement. 
- Added corresponding touch support to planet orbit controls (`src/engine/PlanetOrbitControls.js`) to allow one-finger orbit and two-finger pinch zoom/orbit interactions. 
- Updated the in-app help text in `src/App.jsx` to show touch guidance (pinch to zoom / two-finger pan). 
- Added responsive mobile/touch CSS rules in `src/styles.css` to rearrange the top bar, toolbar, drawer, camera bar and status area for touch and small screens (portrait and landscape safe-area handling and touch-friendly sizes). 

### Testing
- Ran a production build with `npm run build` (Vite) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34098551d88324a300f10e183d1813)