### PR TITLE
Fix mobile camera/touch joystick behavior and minimap spacing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -254,6 +254,9 @@ export default function App() {
   const handleTimeOfDay = (value) => { engine().setTimeOfDay(value); setTimeOfDay(value); };
   const handleBehindCameraCulling = (enabled) => { engine().setBehindCameraCulling(enabled); setBehindCameraCulling(enabled); };
   const handleCullingEnabled = (enabled) => { engine().setCullingEnabled(enabled); setCullingEnabled(enabled); };
+  const handleTouchInput = useCallback((input) => {
+    engineRef.current?.setTouchInput(input);
+  }, []);
 
   // ---- export: blocking overlay, button disabled via panel busy state ----
   const onExport = (options) => {
@@ -416,7 +419,7 @@ export default function App() {
                 onPerfSetting={(key, value) => engine().setPerfSetting(key, value)}
                 onPerfReset={() => engine().resetPerfSettings()}
               />
-              <TouchControls onInput={(input) => engine().setTouchInput(input)} />
+              <TouchControls onInput={handleTouchInput} />
             </>
           )}
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -357,9 +357,9 @@ export default function App() {
           <canvas id="viewport" ref={canvasRef} />
 
           <div id="help-card" className={helpVisible && studioLike ? '' : 'hidden'}>
-            <div className="help-row"><span className="help-ic">🖐</span> Drag to pan</div>
+            <div className="help-row"><span className="help-ic">↻</span> Drag to orbit camera</div>
             <div className="help-row"><span className="help-ic">🤏</span> Pinch to zoom • move two fingers to pan</div>
-            <div className="help-row"><span className="help-ic">↻</span> Right-click + drag to orbit</div>
+            <div className="help-row"><span className="help-ic">🖱</span> Mouse: left pan • right orbit</div>
           </div>
 
           {showStudioUI && isStudio && (

--- a/src/components/StatusBar.jsx
+++ b/src/components/StatusBar.jsx
@@ -14,53 +14,57 @@ const PLAYER_STATE_LABELS = {
 export default function StatusBar({ status, gpu, stats, worldMode, infiniteStats, qualityPreset, playerMode, playerState }) {
   return (
     <footer id="statusbar">
-      <div className="sb-group">
+      <div className="sb-group sb-group-primary">
         <span className={`status-dot${status.busy ? ' busy' : ''}`} />
-        <span>{status.text}</span>
-        <span className="sb-sep" />
-        <span>GPU: {gpu}</span>
+        <span className="sb-status">{status.text}</span>
+        <span className="sb-sep sb-desktop-only" aria-hidden="true" />
+        <span className="sb-desktop-only">GPU: {gpu}</span>
         {playerMode && playerState && (
           <>
-            <span className="sb-sep" />
-            <span className={`player-state player-state-${playerState}`}>
+            <span className="sb-sep sb-desktop-only" aria-hidden="true" />
+            <span className={`player-state player-state-${playerState} sb-desktop-only`}>
               {PLAYER_STATE_LABELS[playerState] ?? playerState}
             </span>
           </>
         )}
         {worldMode === 'infinite' && infiniteStats && (
           <>
-            <span className="sb-sep" />
-            <span>Visible: {infiniteStats.visibleChunks ?? infiniteStats.chunks} / {infiniteStats.chunks}</span>
-            <span className="sb-sep" />
-            <span>Speed: {infiniteStats.speed} u/s</span>
+            <span className="sb-sep sb-desktop-only" aria-hidden="true" />
+            <span className="sb-desktop-only">
+              Visible: {infiniteStats.visibleChunks ?? infiniteStats.chunks} / {infiniteStats.chunks}
+            </span>
+            <span className="sb-sep sb-desktop-only" aria-hidden="true" />
+            <span className="sb-desktop-only">Speed: {infiniteStats.speed} u/s</span>
             {qualityPreset && (
               <>
-                <span className="sb-sep" />
-                <span className="sb-quality">{qualityPreset}</span>
+                <span className="sb-sep sb-desktop-only" aria-hidden="true" />
+                <span className="sb-quality sb-desktop-only">{qualityPreset}</span>
               </>
             )}
           </>
         )}
         {worldMode === 'planet' && (
           <>
-            <span className="sb-sep" />
-            <span>Planet</span>
+            <span className="sb-sep sb-desktop-only" aria-hidden="true" />
+            <span className="sb-desktop-only">Planet</span>
             {infiniteStats && (
               <>
-                <span className="sb-sep" />
-                <span>Visible: {infiniteStats.visibleChunks} / {infiniteStats.chunks}</span>
+                <span className="sb-sep sb-desktop-only" aria-hidden="true" />
+                <span className="sb-desktop-only">
+                  Visible: {infiniteStats.visibleChunks} / {infiniteStats.chunks}
+                </span>
               </>
             )}
           </>
         )}
       </div>
-      <div className="sb-group">
-        <span>Triangles: {fmtTris(stats.triangles)}</span>
-        <span className="sb-sep" />
-        <span>Draw Calls: {stats.drawCalls}</span>
+      <div className="sb-group sb-group-stats">
+        <span className="sb-tris">Triangles: {fmtTris(stats.triangles)}</span>
+        <span className="sb-sep sb-desktop-only" aria-hidden="true" />
+        <span className="sb-desktop-only">Draw Calls: {stats.drawCalls}</span>
         <span className="sb-sep" />
         <span className={`fps-badge${stats.fps > 0 && stats.fps < 30 ? ' low' : ''}`}>{stats.fps} FPS</span>
-        <span className="sb-sep" />
+        <span className="sb-sep sb-desktop-only" aria-hidden="true" />
         <a
           className="sb-github-link"
           href={GITHUB_REPO_URL}

--- a/src/components/TouchControls.jsx
+++ b/src/components/TouchControls.jsx
@@ -32,15 +32,8 @@ function useJoystick(onChange) {
     onChange(0, 0);
   }, [onChange]);
 
-  const onPointerDown = useCallback((e) => {
-    e.preventDefault();
-    e.stopPropagation();
-    activeRef.current = e.pointerId;
-    baseRef.current?.setPointerCapture(e.pointerId);
-  }, []);
-
-  const onPointerMove = useCallback((e) => {
-    if (activeRef.current !== e.pointerId || !baseRef.current || !knobRef.current) return;
+  const updateFromPointer = useCallback((e) => {
+    if (!baseRef.current || !knobRef.current) return;
     const rect = baseRef.current.getBoundingClientRect();
     const cx = rect.left + rect.width / 2;
     const cy = rect.top + rect.height / 2;
@@ -49,6 +42,21 @@ function useJoystick(onChange) {
     knobRef.current.style.transform = `translate(calc(-50% + ${raw.x}px), calc(-50% + ${raw.y}px))`;
     onChange(n.x, n.y);
   }, [onChange]);
+
+  const onPointerDown = useCallback((e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    activeRef.current = e.pointerId;
+    baseRef.current?.setPointerCapture(e.pointerId);
+    updateFromPointer(e);
+  }, [updateFromPointer]);
+
+  const onPointerMove = useCallback((e) => {
+    if (activeRef.current !== e.pointerId) return;
+    e.preventDefault();
+    e.stopPropagation();
+    updateFromPointer(e);
+  }, [updateFromPointer]);
 
   const onPointerUp = useCallback((e) => {
     if (activeRef.current !== e.pointerId) return;

--- a/src/components/TouchControls.jsx
+++ b/src/components/TouchControls.jsx
@@ -23,14 +23,16 @@ function useJoystick(onChange) {
   const baseRef = useRef(null);
   const knobRef = useRef(null);
   const activeRef = useRef(null);
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
 
   const reset = useCallback(() => {
     activeRef.current = null;
     if (knobRef.current) {
       knobRef.current.style.transform = 'translate(-50%, -50%)';
     }
-    onChange(0, 0);
-  }, [onChange]);
+    onChangeRef.current(0, 0);
+  }, []);
 
   const updateFromPointer = useCallback((e) => {
     if (!baseRef.current || !knobRef.current) return;
@@ -40,8 +42,16 @@ function useJoystick(onChange) {
     const raw = clampKnob(e.clientX - cx, e.clientY - cy, RADIUS);
     const n = norm(raw.x, raw.y, RADIUS);
     knobRef.current.style.transform = `translate(calc(-50% + ${raw.x}px), calc(-50% + ${raw.y}px))`;
-    onChange(n.x, n.y);
-  }, [onChange]);
+    onChangeRef.current(n.x, n.y);
+  }, []);
+
+  const endDrag = useCallback((e) => {
+    if (activeRef.current !== e.pointerId) return;
+    if (baseRef.current?.hasPointerCapture(e.pointerId)) {
+      baseRef.current.releasePointerCapture(e.pointerId);
+    }
+    reset();
+  }, [reset]);
 
   const onPointerDown = useCallback((e) => {
     e.preventDefault();
@@ -59,24 +69,22 @@ function useJoystick(onChange) {
   }, [updateFromPointer]);
 
   const onPointerUp = useCallback((e) => {
-    if (activeRef.current !== e.pointerId) return;
-    if (baseRef.current?.hasPointerCapture(e.pointerId)) {
-      baseRef.current.releasePointerCapture(e.pointerId);
-    }
-    reset();
-  }, [reset]);
+    endDrag(e);
+  }, [endDrag]);
 
-  useEffect(() => () => reset(), [reset]);
+  useEffect(() => () => reset(), []);
 
   return { baseRef, knobRef, onPointerDown, onPointerMove, onPointerUp };
 }
 
 export default function TouchControls({ onInput }) {
   const stateRef = useRef({ moveX: 0, moveY: 0, lookX: 0, lookY: 0 });
+  const onInputRef = useRef(onInput);
+  onInputRef.current = onInput;
 
   const sync = useCallback(() => {
-    onInput?.({ ...stateRef.current });
-  }, [onInput]);
+    onInputRef.current?.({ ...stateRef.current });
+  }, []);
 
   const onMove = useCallback((x, y) => {
     stateRef.current.moveX = x;
@@ -93,7 +101,9 @@ export default function TouchControls({ onInput }) {
   const move = useJoystick(onMove);
   const look = useJoystick(onLook);
 
-  useEffect(() => () => onInput?.({ moveX: 0, moveY: 0, lookX: 0, lookY: 0 }), [onInput]);
+  useEffect(() => () => {
+    onInputRef.current?.({ moveX: 0, moveY: 0, lookX: 0, lookY: 0 });
+  }, []);
 
   return (
     <div className="touch-controls">

--- a/src/engine/EditorControls.js
+++ b/src/engine/EditorControls.js
@@ -125,6 +125,13 @@ export class EditorControls {
     this._clampTarget();
   }
 
+  _orbitByPixels(dx, dy) {
+    this.goalTheta -= dx * 0.005;
+    if (this.mode !== 'topdown') {
+      this.goalPhi = Math.min(Math.max(this.goalPhi - dy * 0.004, this.minPhi), this.maxPhi);
+    }
+  }
+
   _getPinchState() {
     const pts = Array.from(this._touches.values());
     if (pts.length < 2) return null;
@@ -149,7 +156,7 @@ export class EditorControls {
         return;
       }
       if (pts.length === 1 && this._pinch === null && prevTouch) {
-        this._panByPixels(e.clientX - prevTouch.x, e.clientY - prevTouch.y);
+        this._orbitByPixels(e.clientX - prevTouch.x, e.clientY - prevTouch.y);
       }
       return;
     }
@@ -160,11 +167,7 @@ export class EditorControls {
     this._drag.y = e.clientY;
 
     if (this._drag.button === 0) this._panByPixels(dx, dy);
-    else {
-      // orbit
-      this.goalTheta -= dx * 0.005;
-      if (this.mode !== 'topdown') this.goalPhi = Math.min(Math.max(this.goalPhi - dy * 0.004, this.minPhi), this.maxPhi);
-    }
+    else this._orbitByPixels(dx, dy);
   }
 
   _onUp(e) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -2702,15 +2702,36 @@ input[type="color"].palette-color-input {
 
   #statusbar {
     height: auto;
-    min-height: 24px;
+    min-height: 34px;
     flex: 0 0 auto;
-    gap: 8px;
-    padding: 4px max(8px, env(safe-area-inset-right)) 4px max(8px, env(safe-area-inset-left));
-    overflow-x: auto;
-    scrollbar-width: none;
+    flex-wrap: nowrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 6px max(10px, env(safe-area-inset-right))
+      calc(6px + env(safe-area-inset-bottom))
+      max(10px, env(safe-area-inset-left));
+    overflow: hidden;
+    font-size: 10px;
   }
-  #statusbar::-webkit-scrollbar { display: none; }
-  .sb-group { flex: 0 0 auto; gap: 8px; }
+  .sb-desktop-only { display: none !important; }
+  .sb-group {
+    flex: 0 1 auto;
+    min-width: 0;
+    gap: 8px;
+    flex-wrap: nowrap;
+    white-space: nowrap;
+  }
+  .sb-group-primary { flex: 1 1 auto; }
+  .sb-group-stats { flex: 0 0 auto; justify-content: flex-end; }
+  .sb-status {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 42vw;
+  }
+  .sb-tris { font-variant-numeric: tabular-nums; }
+  .fps-badge { flex-shrink: 0; }
+  .sb-github-link { flex-shrink: 0; }
 }
 
 @media (hover: none) and (pointer: coarse) and (orientation: landscape) and (max-height: 520px) {
@@ -2740,4 +2761,7 @@ input[type="color"].palette-color-input {
 @media (max-width: 420px) {
   .viewport-mode-bar .mode-bar-btn { padding: 0 9px; font-size: 10px; }
   .toolbar-btn { flex-basis: 50px; min-width: 50px; }
+  #statusbar { gap: 6px; font-size: 9.5px; }
+  .sb-group { gap: 6px; }
+  .sb-status { max-width: 34vw; }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -2062,6 +2062,7 @@ input[type="color"].palette-color-input {
 .minimap-title {
   display: flex;
   align-items: center;
+  gap: 8px;
   font-size: 10px;
   font-weight: 700;
   letter-spacing: 1.2px;
@@ -2087,6 +2088,9 @@ input[type="color"].palette-color-input {
 }
 .minimap-toggle-btn svg {
   display: block;
+}
+.minimap-title svg {
+  flex: 0 0 auto;
 }
 .minimap-overlay-body {
   padding: 10px;


### PR DESCRIPTION
### Motivation
- Mobile touch input was not producing expected camera rotation in the Studio (one-finger drag), and touch joysticks weren’t applying input immediately or reliably while dragging. 
- Two-finger gestures (pan/pinch) and desktop mouse controls needed to remain unchanged. 
- The minimap icon was visually cramped against the title text on small screens and needed spacing for a cleaner UI.

### Description
- Make one-finger touch drags orbit the Studio camera by adding `_orbitByPixels` and invoking it for single-touch moves in `src/engine/EditorControls.js`, while preserving two-finger pan/pinch behavior. 
- Refactor drag handling so desktop mouse behavior still uses left-drag for pan and right-drag for orbit in `src/engine/EditorControls.js`. 
- Ensure mobile joystick updates apply immediately on press, maintain pointer capture during drag, and prevent pointer-event leakage by introducing `updateFromPointer`, and updating the `onPointerDown`/`onPointerMove` handlers in `src/components/TouchControls.jsx`. 
- Update the in-app help text to reflect the mobile orbit/desktop pan-orbit split in `src/App.jsx`. 
- Add spacing and sizing rules to the minimap title/icon to avoid overlap by updating `src/styles.css`.

### Testing
- Ran the production build with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37a7d1a9f08324a7533ef389b4ceee)