### PR TITLE
Fix edge smear on non-square real-world locations (center-crop to square)

### DIFF
--- a/src/engine/terrain/RealWorldHeightmap.js
+++ b/src/engine/terrain/RealWorldHeightmap.js
@@ -191,10 +191,17 @@ export async function fetchLocationHeightmap(loc, { onProgress, signal } = {}) {
   }
 
   // Crop the stitched grid to the exact bounding box.
-  const cropX = Math.max(0, Math.round((fx0 - tx0) * TILE));
-  const cropY = Math.max(0, Math.round((fy0 - ty0) * TILE));
-  const cropW = Math.min(stitch.width - cropX, Math.max(1, Math.round((fx1 - fx0) * TILE)));
-  const cropH = Math.min(stitch.height - cropY, Math.max(1, Math.round((fy1 - fy0) * TILE)));
+  let cropX = Math.max(0, Math.round((fx0 - tx0) * TILE));
+  let cropY = Math.max(0, Math.round((fy0 - ty0) * TILE));
+  let cropW = Math.min(stitch.width - cropX, Math.max(1, Math.round((fx1 - fx0) * TILE)));
+  let cropH = Math.min(stitch.height - cropY, Math.max(1, Math.round((fy1 - fy0) * TILE)));
+  // Center-crop to a square: the board is square, so a non-square bbox would
+  // otherwise clamp-stretch its short-axis edge row into a smear. Trim the long
+  // axis instead (the strip that was getting smeared anyway).
+  const side = Math.min(cropW, cropH);
+  cropX += Math.floor((cropW - side) / 2);
+  cropY += Math.floor((cropH - side) / 2);
+  cropW = cropH = side;
   const id = sctx.getImageData(cropX, cropY, cropW, cropH);
 
   const W = id.width, H = id.height, data = id.data;


### PR DESCRIPTION
Loving the tool — thanks for open-sourcing it. Small bug fix found while exploring the real-world locations.

### Bug
`fetchLocationHeightmap` crops the stitched terrain tiles to the exact bbox, returning a non-square `W×H` float grid whenever the bbox aspect isn't 1:1 (e.g. Grand Canyon `0.40×0.50`, Yosemite `0.26×0.30`). The Tile board is square, so the import resample clamp-stretches the short-axis edge row across the overhang — a visible **smear at one edge**, which also bakes into the GLB/OBJ export.

### Fix
Center-crop the stitched grid to `min(W, H)` before handoff, so the grid is always square and the board never has to stretch. The trimmed strip is the long-axis overhang that was getting smeared anyway; the recognizable terrain stays centered and unaffected.

One-file change, no API change. Verified live across several locations — the edge smear is gone and exports come out clean. Happy to adjust anything.
