### PR TITLE
Top bar: add View layout save/import/export and polish header UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1004,6 +1004,79 @@ export default function App() {
     _soloLayerId: engineRef.current?._soloLayerId ?? null,
   };
 
+
+  const buildViewLayout = useCallback(() => ({
+    version: 1,
+    savedAt: new Date().toISOString(),
+    worldMode,
+    activePanel: effectivePanel,
+    previewMode,
+    paintMode,
+    helpVisible,
+    settingsSearchOpen,
+    camMode,
+  }), [worldMode, effectivePanel, previewMode, paintMode, helpVisible, settingsSearchOpen, camMode]);
+
+  const applyViewLayout = useCallback((layout) => {
+    if (!layout || typeof layout !== 'object') {
+      showToast('Could not import view layout', 'error');
+      return;
+    }
+
+    const nextWorldMode = layout.worldMode;
+    if (nextWorldMode && ['studio', 'infinite', 'planet'].includes(nextWorldMode)) {
+      selectWorldMode(nextWorldMode);
+    }
+
+    setPreviewMode(!!layout.previewMode);
+    setHelpVisible(!!layout.helpVisible);
+    setSettingsSearchOpen(!!layout.settingsSearchOpen);
+    if (typeof layout.paintMode === 'boolean') engine().setPaintMode(layout.paintMode);
+    if (typeof layout.camMode === 'string') setCamMode(layout.camMode);
+
+    const targetMode = ['studio', 'infinite', 'planet'].includes(nextWorldMode) ? nextWorldMode : worldMode;
+    const panelId = typeof layout.activePanel === 'string' ? layout.activePanel : null;
+    setActivePanel(panelId && panelAvailable(panelId, targetMode) ? panelId : null);
+    showToast('View layout applied', 'success');
+  }, [selectWorldMode, showToast, worldMode]);
+
+  const saveViewLayout = useCallback(() => {
+    try {
+      localStorage.setItem('terrain-studio:view-layout', JSON.stringify(buildViewLayout()));
+      showToast('View layout saved', 'success');
+    } catch {
+      showToast('Could not save view layout', 'error');
+    }
+  }, [buildViewLayout, showToast]);
+
+
+  const loadSavedViewLayout = useCallback(() => {
+    try {
+      const raw = localStorage.getItem('terrain-studio:view-layout');
+      if (!raw) {
+        showToast('No saved view layout found', 'info');
+        return;
+      }
+      applyViewLayout(JSON.parse(raw));
+    } catch {
+      showToast('Could not load saved view layout', 'error');
+    }
+  }, [applyViewLayout, showToast]);
+
+  const exportViewLayout = useCallback(() => {
+    const blob = new Blob([JSON.stringify(buildViewLayout(), null, 2)], { type: 'application/json' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'terrain-studio-view-layout.json';
+    a.click();
+    setTimeout(() => URL.revokeObjectURL(a.href), 1000);
+    showToast('View layout exported', 'success');
+  }, [buildViewLayout, showToast]);
+
+  const importViewLayout = useCallback((layout) => {
+    applyViewLayout(layout);
+  }, [applyViewLayout]);
+
   return (
     <div id="app" className={`${previewMode ? 'preview-mode' : ''}${landingMode ? ' landing-mode' : ''}${fpsView ? ' infinite-mode' : ''}${touchExplore ? ' fps-explore-mode' : ''}${exploreMode === 'plane' ? ' plane-mode' : ''}${drawerOpen ? ' side-drawer-open' : ''}${perfOverlay.settings.open ? ' perf-overlay-open' : ''}`}>
       <TopBar
@@ -1029,6 +1102,10 @@ export default function App() {
         canRedo={histState.canRedo}
         onOpenSettingsSearch={openSettingsSearch}
         settingsSearchOpen={settingsSearchOpen}
+        onSaveViewLayout={saveViewLayout}
+        onImportViewLayout={importViewLayout}
+        onLoadSavedViewLayout={loadSavedViewLayout}
+        onExportViewLayout={exportViewLayout}
       />
 
       <div id="main" className="app-shell">

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { APP_NAME, APP_VERSION } from '../constants/app.js';
 import WorldModeBar from './WorldModeBar.jsx';
 
@@ -16,8 +16,21 @@ export default function TopBar({
   paintMode, onTogglePaintMode, onOpenPanel, activePanel,
   loading, modeLocked, onOpenSettingsSearch, settingsSearchOpen,
   onUndo, onRedo, canUndo, canRedo,
+  onSaveViewLayout, onLoadSavedViewLayout, onImportViewLayout, onExportViewLayout,
 }) {
   const fileRef = useRef(null);
+  const layoutFileRef = useRef(null);
+  const viewMenuRef = useRef(null);
+  const [viewMenuOpen, setViewMenuOpen] = useState(false);
+
+  useEffect(() => {
+    if (!viewMenuOpen) return undefined;
+    const close = (event) => {
+      if (!viewMenuRef.current?.contains(event.target)) setViewMenuOpen(false);
+    };
+    window.addEventListener('pointerdown', close);
+    return () => window.removeEventListener('pointerdown', close);
+  }, [viewMenuOpen]);
 
   const onFile = (e) => {
     const file = e.target.files[0];
@@ -29,6 +42,25 @@ export default function TopBar({
     };
     reader.readAsText(file);
     e.target.value = '';
+  };
+
+
+  const onLayoutFile = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      try { onImportViewLayout?.(JSON.parse(reader.result)); }
+      catch { onImportViewLayout?.(null); }
+    };
+    reader.readAsText(file);
+    e.target.value = '';
+    setViewMenuOpen(false);
+  };
+
+  const runViewAction = (action) => {
+    action?.();
+    setViewMenuOpen(false);
   };
 
   return (
@@ -102,6 +134,30 @@ export default function TopBar({
         <button className="tb-btn" onClick={() => fileRef.current.click()} title="Load seed + parameters from JSON">
           <Icon d={['M2 4h4l1.5 2H14v7H2z', 'M8 12V8M8 8l-1.7 1.7M8 8l1.7 1.7']} /> <span className="tb-text">Load</span>
         </button>
+
+        <div className="tb-dropdown" ref={viewMenuRef}>
+          <button
+            type="button"
+            className={`tb-btn tb-view-btn${viewMenuOpen ? ' active' : ''}`}
+            onClick={() => setViewMenuOpen((v) => !v)}
+            aria-haspopup="menu"
+            aria-expanded={viewMenuOpen}
+            title="View layout options"
+          >
+            <svg viewBox="0 0 16 16" aria-hidden>
+              <rect x="2" y="3" width="12" height="10" rx="2" stroke="currentColor" fill="none" strokeWidth="1.2" />
+              <path d="M2 6.5h12M6.2 6.5V13" stroke="currentColor" fill="none" strokeWidth="1.2" />
+            </svg>
+            <span className="tb-text">View</span>
+            <svg className="caret" viewBox="0 0 8 8" aria-hidden><path d="M1.5 3L4 5.5L6.5 3" stroke="currentColor" fill="none" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" /></svg>
+          </button>
+          <div className={`tb-menu tb-view-menu${viewMenuOpen ? ' open' : ''}`} role="menu">
+            <button type="button" role="menuitem" onClick={() => runViewAction(onSaveViewLayout)}>Save current layout</button>
+            <button type="button" role="menuitem" onClick={() => runViewAction(onLoadSavedViewLayout)}>Restore saved layout</button>
+            <button type="button" role="menuitem" onClick={() => layoutFileRef.current?.click()}>Import layout…</button>
+            <button type="button" role="menuitem" onClick={() => runViewAction(onExportViewLayout)}>Export layout…</button>
+          </div>
+        </div>
         <button
           className={`tb-btn${paintMode ? ' active' : ''}`}
           onClick={onTogglePaintMode}
@@ -154,6 +210,7 @@ export default function TopBar({
       </div>
 
       <input type="file" ref={fileRef} accept="application/json" hidden onChange={onFile} />
+      <input type="file" ref={layoutFileRef} accept="application/json" hidden onChange={onLayoutFile} />
     </header>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -60,23 +60,27 @@ body {
   display: flex;
   align-items: center;
   gap: 12px;
-  height: 46px;
-  flex: 0 0 46px;
-  padding: 0 14px;
-  background: var(--bg-panel-soft);
+  height: 50px;
+  flex: 0 0 50px;
+  padding: 0 16px;
+  background:
+    linear-gradient(135deg, rgba(56, 189, 248, 0.12), transparent 28%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.045), transparent),
+    var(--bg-panel-soft);
   border-bottom: 1px solid var(--border-subtle);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.22);
   z-index: 30;
 }
 .tb-group { display: flex; align-items: center; gap: 6px; }
-.tb-brand { gap: 9px; margin-right: 8px; }
+.tb-brand { gap: 10px; margin-right: 8px; padding-right: 12px; border-right: 1px solid var(--border-subtle); }
 .tb-center {
   flex: 1 1 auto;
   justify-content: center;
   min-width: 0;
   gap: 8px;
 }
-.logo { width: 22px; height: 22px; color: var(--accent); flex-shrink: 0; }
-.app-name { font-weight: 700; letter-spacing: 1.5px; font-size: 13px; color: var(--text-bright); }
+.logo { width: 24px; height: 24px; color: var(--accent); flex-shrink: 0; filter: drop-shadow(0 0 10px rgba(56, 189, 248, 0.28)); }
+.app-name { font-weight: 800; letter-spacing: 1.8px; font-size: 13px; color: var(--text-bright); text-transform: uppercase; }
 .app-version { font-size: 10.5px; color: var(--text-dim); font-family: var(--mono); margin-top: 2px; }
 .tb-right { margin-left: auto; }
 
@@ -84,22 +88,24 @@ body {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  height: 28px;
+  height: 30px;
   padding: 0 10px;
-  background: transparent;
-  border: 1px solid transparent;
-  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.018);
+  border: 1px solid rgba(255, 255, 255, 0.035);
+  border-radius: 9px;
   color: var(--text-muted);
   font-family: var(--font);
   font-size: 12px;
   cursor: var(--cursor-pointer);
   white-space: nowrap;
-  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease, transform 0.12s ease, box-shadow 0.12s ease;
 }
+.tb-btn:active { transform: translateY(1px); }
 .tb-btn:hover {
   background: var(--bg-control);
   color: var(--text-main);
-  border-color: var(--border-subtle);
+  border-color: var(--border-active);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.04);
 }
 .tb-btn.active {
   background: var(--accent-bg);
@@ -141,9 +147,10 @@ body {
   flex-shrink: 0;
 }
 .tb-btn.primary {
-  background: var(--accent);
+  background: linear-gradient(135deg, var(--accent), var(--accent-hover));
   color: #fff;
   border-color: var(--accent);
+  box-shadow: 0 8px 20px rgba(56, 189, 248, 0.18);
 }
 .tb-btn.primary:hover { background: var(--accent-hover); border-color: var(--accent-hover); color: #fff; }
 .tb-btn:disabled { opacity: 0.45; cursor: var(--cursor-not-allowed); }
@@ -195,18 +202,20 @@ body {
 .tb-dropdown { position: relative; }
 .tb-menu {
   position: absolute;
-  top: 32px;
+  top: 36px;
   left: 0;
-  min-width: 170px;
-  background: var(--bg-panel);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-sm);
-  padding: 4px;
+  min-width: 190px;
+  background: color-mix(in srgb, var(--bg-panel) 94%, #ffffff 6%);
+  border: 1px solid var(--border-active);
+  border-radius: 12px;
+  padding: 6px;
   display: none;
   flex-direction: column;
   z-index: 50;
-  box-shadow: var(--shadow-panel);
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.38);
 }
+.tb-view-btn { background: rgba(56, 189, 248, 0.07); border-color: rgba(56, 189, 248, 0.16); color: var(--text-main); }
+.tb-view-menu button + button { margin-top: 2px; }
 .tb-menu.open { display: flex; }
 .tb-menu button {
   background: none;
@@ -3596,7 +3605,7 @@ input[type="color"].palette-color-input {
     touch-action: pan-x;
   }
   #topbar::-webkit-scrollbar { display: none; }
-  .tb-brand { margin-right: 0; flex: 0 0 auto; padding-right: 2px; }
+  .tb-brand { margin-right: 0; flex: 0 0 auto; padding-right: 2px; border-right: none; }
   .tb-brand .logo { width: 18px; height: 18px; }
   .app-name { display: none; }
   .app-version { display: none; }


### PR DESCRIPTION
### Motivation
- Provide persistent and portable view/layout controls so the UI state (panel, mode, preview/paint, camera mode, etc.) can be saved, restored, imported and exported. 
- Improve the top header's visual design and affordances for a clearer, more polished toolbar. 
- Attempt to investigate a reported GraphView runtime issue, but the repository contains no `GraphView.tsx` to patch so that specific error could not be fixed here.

### Description
- Add view-layout serialization and application helpers in `src/App.jsx`: `buildViewLayout`, `applyViewLayout`, `saveViewLayout`, `loadSavedViewLayout`, `exportViewLayout`, and `importViewLayout`, using the localStorage key `terrain-studio:view-layout` and JSON export/import. 
- Wire new handlers into the top bar props so the header can trigger save/restore/import/export operations. 
- Add a new View dropdown in `src/components/TopBar.jsx` with actions: Save current layout, Restore saved layout, Import layout (JSON file input), and Export layout (download). 
- Refresh header styling in `src/styles.css` with a taller bar, gradient/highlight accents, refined button chrome, dropdown polish and small UX tweaks (button hover/active, shadows, spacing, logo treatment).

### Testing
- Ran `npm run build` (Vite production build) and the build completed successfully. 
- Ran repo checks with `git diff --check` and no style/whitespace errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a484e2c5e308324a94ed2b12753f387)