### PR TITLE
Fix custom-material worker baking and texture imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "terrain-studio",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "terrain-studio",
-      "version": "1.8.2",
+      "version": "1.8.3",
       "dependencies": {
         "@xyflow/react": "^12.11.2",
         "fflate": "^0.8.3",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "ZyFou",
   "main": "electron/main.cjs",
   "private": true,
-  "version": "1.8.2",
+  "version": "1.8.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ui/SurfaceLibraryPanel.jsx
+++ b/src/components/ui/SurfaceLibraryPanel.jsx
@@ -5,7 +5,10 @@ import CollapsibleGroup from './CollapsibleGroup.jsx';
 import SurfaceMaterialPreviewSphere from './SurfaceMaterialPreviewSphere.jsx';
 import { SliderCtl, ToggleRow, SelectRow } from '../controls.jsx';
 import { colorToHex } from '../../engine/style/ColorPalette.js';
-import { detectSlotFromFilename } from '../../engine/terrain/surface/SurfaceTextureDetector.js';
+import {
+  collectSurfaceTextureSets, planSurfaceTextureImport,
+  SURFACE_IMAGE_EXT_RE, mimeForSurfaceTexture,
+} from '../../engine/terrain/surface/SurfaceTextureImport.js';
 import {
   loadMaterialsManifest, resolveCustomMapUrl,
   setOverrideUrl, clearOverrideUrl, getOverrideUrl, MAP_SLOT_LABELS,
@@ -24,13 +27,13 @@ import {
 
 const PREVIEW_SLOTS = ['diffuse', 'normalDX', 'roughness', 'ao'];
 const RENDERED_SLOTS = new Set(PREVIEW_SLOTS);
-const IMAGE_EXT_RE = /\.(png|jpe?g|webp|avif|gif|bmp)$/i;
 const ZIP_EXT_RE = /\.zip$/i;
 
 const STATUS_LABEL = {
   checking: '...',
   custom: 'Custom',
   missing: 'Missing',
+  invalid: 'Unsupported file',
 };
 
 const LAYER_STATUS_LABEL = {
@@ -59,81 +62,44 @@ function previewUrlsFor(role, variantIndex) {
   return urls;
 }
 
-function mimeForTextureName(name) {
-  const lower = name.toLowerCase();
-  if (lower.endsWith('.png')) return 'image/png';
-  if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return 'image/jpeg';
-  if (lower.endsWith('.webp')) return 'image/webp';
-  if (lower.endsWith('.avif')) return 'image/avif';
-  if (lower.endsWith('.gif')) return 'image/gif';
-  if (lower.endsWith('.bmp')) return 'image/bmp';
-  return 'application/octet-stream';
-}
-
 function isZipFile(file) {
   return ZIP_EXT_RE.test(file.name) || file.type === 'application/zip' || file.type === 'application/x-zip-compressed';
 }
 
-function isTextureEntryPath(name) {
-  const normalized = name.replace(/\\/g, '/').toLowerCase();
-  return normalized.startsWith('textures/') || normalized.includes('/textures/');
-}
-
-async function textureFilesFromZip(file, mapSlots) {
-  const bytes = new Uint8Array(await file.arrayBuffer());
-  const entries = unzipSync(bytes);
-  const matchedBySlot = new Map();
-  const unmatched = [];
-
-  Object.entries(entries).forEach(([entryName, data]) => {
-    if (!data?.length || !isTextureEntryPath(entryName) || !IMAGE_EXT_RE.test(entryName)) return;
-    const slot = detectSlotFromFilename(entryName);
-    if (!slot || !mapSlots.includes(slot)) {
-      unmatched.push(entryName.split(/[\\/]/).pop() || entryName);
-      return;
-    }
-    if (matchedBySlot.has(slot)) return;
-    const blob = new Blob([data], { type: mimeForTextureName(entryName) });
-    matchedBySlot.set(slot, {
-      name: entryName.split(/[\\/]/).pop() || entryName,
-      url: URL.createObjectURL(blob),
-    });
-  });
-
-  return { matchedBySlot, unmatched };
-}
-
 async function importDroppedTextures({ files, role, mapSlots, variantIndex }) {
-  const matched = [];
-  const unmatched = [];
-  const variantKey = getCustomVariantKey(variantIndex);
-  const filledSlots = new Set();
-
+  const entries = [];
+  const warnings = [];
   for (const file of files) {
     if (isZipFile(file)) {
-      const { matchedBySlot, unmatched: zipUnmatched } = await textureFilesFromZip(file, mapSlots);
-      for (const [slot, item] of matchedBySlot.entries()) {
-        if (filledSlots.has(slot)) continue;
-        setOverrideUrl(role.id, variantKey, slot, item.url);
-        filledSlots.add(slot);
-        matched.push(`${MAP_SLOT_LABELS[slot]} (${item.name})`);
+      try {
+        const unpacked = unzipSync(new Uint8Array(await file.arrayBuffer()));
+        let count = 0;
+        for (const [name, data] of Object.entries(unpacked)) {
+          if (!data?.length || name.endsWith('/')) continue;
+          entries.push({ name, scope: file.name, blob: new Blob([data], { type: mimeForSurfaceTexture(name) }) });
+          if (SURFACE_IMAGE_EXT_RE.test(name)) count += 1;
+        }
+        if (!count) warnings.push(`${file.name}: no supported image maps found`);
+      } catch {
+        warnings.push(`${file.name}: could not read ZIP`);
       }
-      if (!matchedBySlot.size) unmatched.push(file.name);
-      else unmatched.push(...zipUnmatched.slice(0, 4));
-      continue;
-    }
-
-    const slot = detectSlotFromFilename(file.name);
-    if (slot && mapSlots.includes(slot) && IMAGE_EXT_RE.test(file.name) && !filledSlots.has(slot)) {
-      setOverrideUrl(role.id, variantKey, slot, URL.createObjectURL(file));
-      filledSlots.add(slot);
-      matched.push(`${MAP_SLOT_LABELS[slot]} (${file.name})`);
     } else {
-      unmatched.push(file.name);
+      entries.push({ name: file.name, blob: file });
     }
   }
-
-  return { matched, unmatched: unmatched.slice(0, 6) };
+  const { sets, unmatched } = collectSurfaceTextureSets(entries, mapSlots);
+  const plan = planSurfaceTextureImport(sets, variantIndex, (index) =>
+    mapSlots.every((slot) => !resolveCustomMapUrl(role, slot, index))
+  );
+  const matched = [];
+  // Apply the complete import in one synchronous batch so the debounced bake
+  // cannot capture half of a slowly decompressed multi-variant archive.
+  for (const entry of plan.assignments) {
+    setOverrideUrl(role.id, getCustomVariantKey(entry.variantIndex), entry.slot, URL.createObjectURL(entry.blob));
+    matched.push(`V${entry.variantIndex + 1} ${MAP_SLOT_LABELS[entry.slot]} (${entry.name})`);
+  }
+  const skipped = [...warnings, ...unmatched, ...plan.unmatched];
+  return { matched, unmatched: skipped.length > 6 ? [...skipped.slice(0, 6), `${skipped.length - 6} more skipped files/sets`] : skipped };
 }
 
 function FileSlotRow({ role, variantIndex, slot, onChanged }) {
@@ -149,6 +115,7 @@ function FileSlotRow({ role, variantIndex, slot, onChanged }) {
   }, [resolved]);
 
   const pick = (file) => {
+    if (!SURFACE_IMAGE_EXT_RE.test(file.name)) { setStatus('invalid'); return; }
     const url = URL.createObjectURL(file);
     setOverrideUrl(role.id, variantKey, slot, url);
     onChanged();
@@ -175,10 +142,12 @@ function FileSlotRow({ role, variantIndex, slot, onChanged }) {
       onDragLeave={() => setDragOver(false)}
       onDrop={(e) => {
         e.preventDefault();
-        e.stopPropagation();
         setDragOver(false);
-        const file = e.dataTransfer.files?.[0];
-        if (file) pick(file);
+        const files = [...(e.dataTransfer.files || [])];
+        // A ZIP or a batch dropped over a slot still belongs to the variant.
+        if (files.length !== 1 || isZipFile(files[0])) return;
+        e.stopPropagation();
+        pick(files[0]);
       }}
     >
       <span className="surface-slot-label">{MAP_SLOT_LABELS[slot]}</span>
@@ -227,9 +196,8 @@ function VariantBlock({ role, variantIndex, mapSlots, atlasVariant, onMaterialCh
     if (!files.length) return;
     setImporting(true);
     try {
-      // Drop a ZIP containing textures/*_diff_*, *_nor_dx_*, *_rough_* and *_ao_*,
-      // or drop loose image maps directly onto the active variant.
-      // The first valid map per slot wins so accidental duplicates are ignored.
+      // Root/nested ZIPs and loose maps are grouped into named sets. The
+      // active variant receives the first set; extras fill empty variants.
       const { matched, unmatched } = await importDroppedTextures({ files, role, mapSlots, variantIndex });
       if (matched.length) onMaterialChanged?.();
       setDropSummary({ matched, unmatched });
@@ -296,7 +264,7 @@ function VariantBlock({ role, variantIndex, mapSlots, atlasVariant, onMaterialCh
       {dropSummary && (
         <p className="section-hint surface-drop-summary">
           {dropSummary.matched.length > 0 && <>Matched: {dropSummary.matched.join(', ')}. </>}
-          {dropSummary.unmatched.length > 0 && <span className="warning">Could not match: {dropSummary.unmatched.join(', ')}.</span>}
+          {dropSummary.unmatched.length > 0 && <span className="warning">Skipped: {dropSummary.unmatched.join(', ')}.</span>}
         </p>
       )}
     </div>
@@ -309,13 +277,11 @@ function variantFromTarget(targetId, roleId) {
   return Math.max(0, Math.min(SURFACE_TEXTURE_VARIANT_COUNT - 1, Number(match[1]) || 0));
 }
 
-function firstAvailableVariantIndex(role, atlasLayer) {
-  for (let variantIndex = 0; variantIndex < SURFACE_TEXTURE_VARIANT_COUNT; variantIndex += 1) {
-    if (!resolveCustomMapUrl(role, 'diffuse', variantIndex)) return variantIndex;
+function firstAvailableVariantIndex(role, mapSlots) {
+  for (let index = 0; index < SURFACE_TEXTURE_VARIANT_COUNT; index += 1) {
+    if (mapSlots.every((slot) => !resolveCustomMapUrl(role, slot, index))) return index;
   }
-  const variants = atlasLayer?.variants || [];
-  const emptyIndex = variants.findIndex((variant) => !variant?.hasDiffuse);
-  return emptyIndex >= 0 ? emptyIndex : 0;
+  return -1;
 }
 
 function RoleCard({ role, mapSlots, targetId, atlasLayer, palette, onMaterialChanged }) {
@@ -323,6 +289,7 @@ function RoleCard({ role, mapSlots, targetId, atlasLayer, palette, onMaterialCha
   const [activeVariant, setActiveVariant] = useState(() => variantFromTarget(targetId, role.id));
   const [forceOpenAfterDrop, setForceOpenAfterDrop] = useState(false);
   const [roleDragOver, setRoleDragOver] = useState(false);
+  const [roleDropSummary, setRoleDropSummary] = useState(null);
   const paletteHex = colorToHex(palette?.[role.id] ?? [0.5, 0.5, 0.5]);
   const layerStatus = atlasLayer?.status ?? 'notBaked';
   const statusLabel = LAYER_STATUS_LABEL[layerStatus] ?? 'Not baked';
@@ -352,15 +319,20 @@ function RoleCard({ role, mapSlots, targetId, atlasLayer, palette, onMaterialCha
         setRoleDragOver(false);
         const files = [...(e.dataTransfer.files || [])];
         if (!files.length) return;
-        const nextVariant = firstAvailableVariantIndex(role, atlasLayer);
+        const nextVariant = firstAvailableVariantIndex(role, mapSlots);
+        if (nextVariant < 0) {
+          setRoleDropSummary({ matched: [], unmatched: ['All variants contain maps. Open a variant to replace it.'] });
+          return;
+        }
         setActiveVariant(nextVariant);
         setOpen(true);
         setForceOpenAfterDrop(true);
         try {
-          const { matched } = await importDroppedTextures({ files, role, mapSlots, variantIndex: nextVariant });
-          if (matched.length) onMaterialChanged?.();
-        } catch {
-          // Variant panel import shows detailed failures; closed-row drops stay quiet.
+          const summary = await importDroppedTextures({ files, role, mapSlots, variantIndex: nextVariant });
+          setRoleDropSummary(summary);
+          if (summary.matched.length) onMaterialChanged?.();
+        } catch (err) {
+          setRoleDropSummary({ matched: [], unmatched: [err.message || 'Texture import failed'] });
         }
       }}
     >
@@ -424,6 +396,12 @@ function RoleCard({ role, mapSlots, targetId, atlasLayer, palette, onMaterialCha
           </>
         )}
       </CollapsibleGroup>
+      {roleDropSummary && (
+        <p className="section-hint surface-drop-summary" role="status">
+          {roleDropSummary.matched.length > 0 && <>Imported: {roleDropSummary.matched.join(', ')}. </>}
+          {roleDropSummary.unmatched.length > 0 && <span className="warning">Skipped: {roleDropSummary.unmatched.join(', ')}.</span>}
+        </p>
+      )}
     </div>
   );
 }
@@ -443,7 +421,7 @@ function SurfaceModeControls({ ctx, source, onBake, applying, status }) {
   const coverage = status?.coverage;
   const coverageClass = !textureMode
     ? ''
-    : coverage?.missingDiffuse ? 'warning'
+    : status?.error || coverage?.missingDiffuse ? 'warning'
       : coverage?.missingOptional ? 'pending'
         : 'ok';
 
@@ -468,9 +446,11 @@ function SurfaceModeControls({ ctx, source, onBake, applying, status }) {
               {applying ? 'Baking...' : 'Bake Custom Materials'}
             </button>
             <span className={`surface-apply-status ${coverageClass}`}>
-              {applying ? 'Building atlas' : coverageText(coverage)}
+              {applying ? 'Building atlas' : status?.error ? 'Bake failed' : coverageText(coverage)}
             </span>
           </div>
+          {status?.error && <p className="section-hint warning" role="alert">{status.error} Use Bake Custom Materials to retry.</p>}
+          <p className="section-hint">One diffuse map per material role is enough; extra variants and other maps are optional. Drop named sets onto the intended role to fill up to four variants. Uploads last for this browser session.</p>
           {SURFACE_MODE_SLIDERS.map((def) => (
             <SliderCtl
               key={def.key}
@@ -503,6 +483,9 @@ export default function SurfaceLibraryPanel({ ctx }) {
   const [applying, setApplying] = useState(false);
   const [status, setStatus] = useState(null);
   const bakeTimerRef = useRef(null);
+  const bakeRequestRef = useRef(0);
+  const sourceRef = useRef(source);
+  sourceRef.current = source;
 
   useEffect(() => {
     let cancelled = false;
@@ -523,17 +506,20 @@ export default function SurfaceLibraryPanel({ ctx }) {
       setStatus(null);
       return null;
     }
+    const request = ++bakeRequestRef.current;
     setApplying(true);
-    setStatus((cur) => ({ ...(cur || {}), source: requestedSource, building: true }));
+    setStatus((cur) => ({ ...(cur || {}), source: requestedSource, building: true, error: null }));
     try {
       const res = await ctx.onApplySurfaceTextures({ source: requestedSource, force });
-      setStatus(res);
+      if (request === bakeRequestRef.current && sourceRef.current === requestedSource) setStatus(res);
       return res;
-    } catch {
-      setStatus({ source: requestedSource, error: true });
+    } catch (err) {
+      if (request === bakeRequestRef.current && sourceRef.current === requestedSource) {
+        setStatus({ source: requestedSource, error: err.message || 'Could not bake custom materials.' });
+      }
       return null;
     } finally {
-      setApplying(false);
+      if (request === bakeRequestRef.current && sourceRef.current === requestedSource) setApplying(false);
     }
   }, [ctx, source]);
 
@@ -547,17 +533,21 @@ export default function SurfaceLibraryPanel({ ctx }) {
     }, 160);
   }, [bake, source]);
 
-  useEffect(() => () => {
-    if (bakeTimerRef.current) window.clearTimeout(bakeTimerRef.current);
-  }, []);
+  useEffect(() => {
+    setApplying(false);
+    return () => {
+      bakeRequestRef.current += 1;
+      if (bakeTimerRef.current) window.clearTimeout(bakeTimerRef.current);
+    };
+  }, [source]);
 
   useEffect(() => {
     if (!sourceUsesTextureAtlas(source)) {
       setStatus(null);
       return;
     }
-    if (status?.source !== source || (!status?.coverage && !status?.building)) bake({ source });
-  }, [bake, source, status?.source, status?.coverage, status?.building]);
+    if (status?.source !== source || (!status?.coverage && !status?.building && !status?.error)) bake({ source });
+  }, [bake, source, status?.source, status?.coverage, status?.building, status?.error]);
 
   useEffect(() => {
     if (libraryRevision && sourceUsesTextureAtlas(source)) scheduleBake();

--- a/src/engine/Engine.js
+++ b/src/engine/Engine.js
@@ -761,7 +761,7 @@ export class Engine {
       this.uniforms,
       oct,
       this._stackGLSL,
-      { variant: this._targetTerrainVariant() },
+      { variant: this._targetTerrainVariant(), worldMode: 'studio' },
     );
     this.board = new TerrainBoard(this.scene, this.terrainMaterial);
 
@@ -934,10 +934,17 @@ export class Engine {
     uniforms.uPaintBiomeTexture.value = this.paintMode.layers.biomeTexture;
     uniforms.uPaintPropsTexture.value = this.paintMode.layers.propsTexture;
     if (manual) {
-      this.manualTerrain.surfaceField.bind(uniforms);
+      // The Manual surface shader reads its packed A/B maps through the two
+      // existing paint sampler units. This keeps the hybrid/custom terrain
+      // program within WebGL's guaranteed 16 fragment texture units.
+      this.manualTerrain.surfaceField.bind(uniforms, { aliasPaintTextures: true });
       uniforms.uManualSurfaceMode.value = 1;
       uniforms.uManualBaseGenerated.value = this._manualHasGeneratedBase() ? 1 : 0;
     } else {
+      // Clear the alias when returning to a standard project. The field stays
+      // bound so a later lazy allocation cannot put Manual textures back into
+      // the standard paint uniforms.
+      this.manualTerrain?.surfaceField?.bind(uniforms, { aliasPaintTextures: false });
       uniforms.uManualSurfaceMode.value = 0;
       uniforms.uManualBaseGenerated.value = 0;
     }
@@ -3687,7 +3694,10 @@ export class Engine {
     try {
       warm = [nodePreviewMaterial
         ? createBootTerrainMaterial(this.uniforms, oct, sg)
-        : createTerrainMaterial(this.uniforms, oct, sg, { variant: terrainVariant })];
+        : createTerrainMaterial(this.uniforms, oct, sg, {
+          variant: terrainVariant,
+          worldMode: modeAtStart === 'infinite' ? 'infinite' : 'studio',
+        })];
       const waterActive = this.params.waterEnabled !== false;
       if ((heightSourceChanged || octavesChanged) && waterActive) {
         if (this.worldMode === 'infinite') {
@@ -3814,14 +3824,20 @@ export class Engine {
         }
         if (modeAtStart === 'studio') {
           if (nodePreviewMaterial) rebuildTerrainPreviewShaderSource(this.terrainMaterial, sg);
-          else rebuildTerrainShaderSource(this.terrainMaterial, sg, { variant: terrainVariant });
+           else rebuildTerrainShaderSource(this.terrainMaterial, sg, {
+             variant: terrainVariant,
+             worldMode: 'studio',
+           });
           if (heightSourceChanged
               && this.waterMaterial
               && !this.waterSystem?.ownsMaterial?.(this.waterMaterial)) {
             rebuildWaterShaderSource(this.waterMaterial, sg);
           }
         } else if (this._infiniteTerrainMat) {
-          rebuildTerrainShaderSource(this._infiniteTerrainMat, sg, { variant: terrainVariant });
+          rebuildTerrainShaderSource(this._infiniteTerrainMat, sg, {
+            variant: terrainVariant,
+            worldMode: 'infinite',
+          });
         }
         if (heightSourceChanged && this._infiniteWaterMat && !this.waterSystem?.ownsMaterial(this._infiniteWaterMat)) {
           rebuildWaterShaderSource(this._infiniteWaterMat, sg);
@@ -6845,7 +6861,10 @@ export class Engine {
       const t0 = performance.now();
       const oct = this.terrainMaterial.defines.OCTAVES;
       const heightProgram = this._activeHeightProgram('studio');
-      const warm = createTerrainMaterial(this.uniforms, oct, heightProgram, { variant });
+      const warm = createTerrainMaterial(this.uniforms, oct, heightProgram, {
+        variant,
+        worldMode: 'studio',
+      });
       const targetSnapshot = this._resolveCameraCompileTarget();
       const workId = `terrain-${variant}`;
       this._bgWorkStart(workId, variant === 'base'
@@ -6878,7 +6897,10 @@ export class Engine {
             this.terrainMaterial.defines.OCTAVES === oct &&
             this._activeHeightProgram('studio').sig === heightProgram.sig) {
           const tSwap = performance.now();
-          rebuildTerrainShaderSource(this.terrainMaterial, heightProgram, { variant });
+          rebuildTerrainShaderSource(this.terrainMaterial, heightProgram, {
+            variant,
+            worldMode: 'studio',
+          });
           swapMs = performance.now() - tSwap;
           swapped = true;
           this._needsRender = true;
@@ -8920,7 +8942,7 @@ export class Engine {
       this.uniforms,
       oct,
       this._stackGLSL,
-      { variant: this._targetTerrainVariant() },
+      { variant: this._targetTerrainVariant(), worldMode: 'infinite' },
     );
     this._infiniteTerrainMat.userData.modeCacheRole = 'infinite-terrain';
     this._infiniteTerrainMat.wireframe = p.wireframe;
@@ -10271,7 +10293,10 @@ export class Engine {
       this.uniforms,
       oct,
       program,
-      { variant },
+      {
+        variant,
+        worldMode: mode === 'infinite' ? 'infinite' : 'studio',
+      },
     );
     this._terrainVariantCompiling = true;
     this._bgWorkStart('terrain-variant', `Preparing ${variant} terrain shader…`);
@@ -10319,7 +10344,10 @@ export class Engine {
         ? this._infiniteTerrainMat
         : this.terrainMaterial;
       if (!target || target.userData?.minimalFragment) return false;
-      rebuildTerrainShaderSource(target, program, { variant });
+      rebuildTerrainShaderSource(target, program, {
+        variant,
+        worldMode: mode === 'infinite' ? 'infinite' : 'studio',
+      });
       this._needsRender = true;
       this._terrainVariantRetryCount = 0;
       this._terrainVariantFailed = false;

--- a/src/engine/EngineProxy.js
+++ b/src/engine/EngineProxy.js
@@ -93,6 +93,7 @@ export class WorkerEngineTransport {
     this.pending = new Map();
     this.nextId = 1;
     this.nextCallbackId = 1;
+    this.surfaceAtlasRevision = 0;
     this.remoteCallbacks = new Map();
     this.onEvent = null;
     this.inputBridge = null;
@@ -139,6 +140,7 @@ export class WorkerEngineTransport {
       this.minimapPresenter.setCanvases(args[0], args[1]);
       return null;
     }
+    if (method === 'buildAndSetSurfaceAtlas') return this._buildSurfaceAtlas(args[0], signal);
     const callbackIds = [];
     const encodedArgs = this._encodeCallbacks(args, callbackIds);
     const result = this._request('invoke', [method, encodedArgs], transfer, signal);
@@ -148,6 +150,15 @@ export class WorkerEngineTransport {
     return Promise.resolve(result).finally(() => {
       callbackIds.forEach((id) => this.remoteCallbacks.delete(id));
     });
+  }
+
+  async _buildSurfaceAtlas(source, signal) {
+    const revision = ++this.surfaceAtlasRevision;
+    const { captureSurfaceAtlasMaps, surfaceAtlasSuperseded } = await import('./terrain/surface/SurfaceAtlasBridge.js');
+    const maps = await captureSurfaceAtlasMaps(source, { signal });
+    if (signal?.aborted) throw Object.assign(new Error('Engine command cancelled'), { code: 'ENGINE_COMMAND_CANCELLED' });
+    if (revision !== this.surfaceAtlasRevision) throw surfaceAtlasSuperseded();
+    return this._request('invoke', ['buildAndSetSurfaceAtlas', [source, maps, revision]], [], signal);
   }
 
   _encodeCallbacks(value, callbackIds, seen = new WeakMap()) {

--- a/src/engine/EngineProxy.js
+++ b/src/engine/EngineProxy.js
@@ -154,8 +154,13 @@ export class WorkerEngineTransport {
 
   async _buildSurfaceAtlas(source, signal) {
     const revision = ++this.surfaceAtlasRevision;
-    const { captureSurfaceAtlasMaps, surfaceAtlasSuperseded } = await import('./terrain/surface/SurfaceAtlasBridge.js');
-    const maps = await captureSurfaceAtlasMaps(source, { signal });
+    const { captureSurfaceAtlasMapRefs, captureSurfaceAtlasMaps, surfaceAtlasSuperseded } = await import('./terrain/surface/SurfaceAtlasBridge.js');
+    let maps;
+    try {
+      maps = await captureSurfaceAtlasMapRefs(source, { signal });
+    } catch {
+      maps = await captureSurfaceAtlasMaps(source, { signal });
+    }
     if (signal?.aborted) throw Object.assign(new Error('Engine command cancelled'), { code: 'ENGINE_COMMAND_CANCELLED' });
     if (revision !== this.surfaceAtlasRevision) throw surfaceAtlasSuperseded();
     return this._request('invoke', ['buildAndSetSurfaceAtlas', [source, maps, revision]], [], signal);

--- a/src/engine/engine.worker.js
+++ b/src/engine/engine.worker.js
@@ -76,6 +76,7 @@ class WorkerCanvasFacade extends TerrainEventTarget {
 
 let engine = null;
 let sequence = 0;
+let surfaceAtlasRevision = 0;
 const allowedMethods = new Set(ENGINE_METHODS);
 const cancelledRequests = new Set();
 
@@ -226,7 +227,19 @@ self.onmessage = async ({ data }) => {
     if (!allowedMethods.has(method) || typeof engine?.[method] !== 'function') {
       throw new Error(`Unknown engine method: ${method}`);
     }
-    const engineResult = await engine[method](...(methodArgs || []));
+    let engineResult;
+    if (method === 'buildAndSetSurfaceAtlas') {
+      const [source, customMaps, revision] = methodArgs;
+      const { buildAndInstallSurfaceAtlas, surfaceAtlasSuperseded } = await import('./terrain/surface/SurfaceAtlasBridge.js');
+      if (!Number.isFinite(revision) || revision < surfaceAtlasRevision) throw surfaceAtlasSuperseded();
+      surfaceAtlasRevision = revision;
+      const target = engine;
+      engineResult = await buildAndInstallSurfaceAtlas(target, source, customMaps, {
+        isCurrent: () => engine === target && revision === surfaceAtlasRevision && !cancelledRequests.has(id),
+      });
+    } else {
+      engineResult = await engine[method](...(methodArgs || []));
+    }
     const result = await prepareWorkerResult(method, engineResult);
     if (!cancelledRequests.delete(id)) postResult(id, result);
   } catch (error) {

--- a/src/engine/terrain/TerrainMaterial.js
+++ b/src/engine/terrain/TerrainMaterial.js
@@ -37,8 +37,11 @@ import { DEFAULT_PLANET_STYLE } from '../style/PlanetStyleConfig.js';
 // ============================================================================
 
 const MANUAL_ACTIVE_COMMON_SAMPLERS = new Set([
-  'uManualSurfaceTextureA',
-  'uManualSurfaceTextureB',
+  // Manual surface weights reuse the two authoring mask units. Keeping a
+  // second pair of samplers here is what pushed the hybrid shader over the
+  // guaranteed WebGL2 fragment budget once the surface atlas was enabled.
+  'uPaintBiomeTexture',
+  'uPaintPropsTexture',
   'uManualHeightTexture',
   'uTileOccupancy',
   'uDestructionTexture',
@@ -47,6 +50,26 @@ const MANUAL_ACTIVE_COMMON_SAMPLERS = new Set([
 const MANUAL_COMMON_UNIFORMS_GLSL = COMMON_UNIFORMS_GLSL.replace(
   /^uniform sampler2D ([A-Za-z0-9_]+);.*$/gm,
   (line, name) => (MANUAL_ACTIVE_COMMON_SAMPLERS.has(name) ? line : ''),
+);
+
+// Standard terrain never reads the standalone Manual surface textures. Manual
+// weights are packed into the existing paint biome/props units (see
+// MANUAL_SURFACE_WEIGHTS_GLSL), so declaring the old pair here would reserve
+// two more fragment texture units for no reason.
+const TERRAIN_COMMON_UNIFORMS_GLSL = COMMON_UNIFORMS_GLSL.replace(
+  /^uniform sampler2D (uManualSurfaceTextureA|uManualSurfaceTextureB|uSplineAuxTexture);.*$/gm,
+  '',
+);
+
+// Infinite terrain is rendered only after its clipmap program has been
+// prepared. Do not keep a procedural fallback in this material: that fallback
+// pulls every Studio authoring sampler into the live program and can take the
+// surface variant past MAX_TEXTURE_IMAGE_UNITS. The clipmap's ready flag still
+// drives the normal path; an unavailable sample is a temporary zero-height
+// value until the prepared cache is published.
+const INFINITE_FIELD_CACHE_STRICT_GLSL = INFINITE_FIELD_CACHE_GLSL.replace(
+  'return available > 0.5 ? field.r * uHeightScale : heightAt(xz);',
+  'return available > 0.5 ? field.r * uHeightScale : 0.0;',
 );
 
 const MANUAL_HEIGHT_GLSL = /* glsl */ `
@@ -115,116 +138,6 @@ Climate terrainCachedClimateAt(vec2 xz) {
   return climateAt(xz * uFrequency + uSeedOffset);
 }
 `;
-
-const buildVertex = (heightGLSL, variant = 'full') => {
-  const features = resolveTerrainVariant(variant);
-  const manual = features.manual;
-  const preview = variant === 'preview';
-  return /* glsl */ `
-${manual ? MANUAL_COMMON_UNIFORMS_GLSL : COMMON_UNIFORMS_GLSL}
-${NOISE_GLSL}
-${BIOME_GLSL}
-${heightGLSL}
-${manual
-    ? MANUAL_TERRAIN_CACHE_GLSL
-    : features.tileOnly
-      ? HYBRID_TILE_TERRAIN_CACHE_GLSL
-      : INFINITE_FIELD_CACHE_GLSL}
-
-uniform float uSkirtDepth;
-uniform float uPlinthBaseY;
-uniform float uWallThickness;
-${preview ? 'uniform float uEps;' : ''}
-
-attribute float aSkirt;
-attribute float aLod;
-attribute float aWall;   // 1 on the dedicated circular radial-wall mesh, else 0
-
-varying vec3  vWorldPos;
-varying float vLod;
-varying float vSkirt;
-varying float vWall;
-varying float vWallMesh;
-${preview ? 'varying vec3 vTerrainPreviewNormal;' : ''}
-
-void main() {
-  vec4 localPosition = vec4(position, 1.0);
-  #ifdef USE_INSTANCING
-    localPosition = instanceMatrix * localPosition;
-  #endif
-  vec4 wp = modelMatrix * localPosition;
-  float h = terrainCachedHeightAt(wp.xz);
-${preview ? /* glsl */ `
-  // Smooth lighting for the lightweight Node preview. Two extra height
-  // samples per vertex are much cheaper than evaluating the graph per pixel,
-  // and interpolate cleanly across the visible terrain triangles.
-  float normalEps = max(uEps, 0.001);
-  float hNormalX = terrainCachedHeightAt(wp.xz + vec2(normalEps, 0.0));
-  float hNormalZ = terrainCachedHeightAt(wp.xz + vec2(0.0, normalEps));
-  vTerrainPreviewNormal = normalize(vec3(
-    -(hNormalX - h) / normalEps,
-    1.0,
-    -(hNormalZ - h) / normalEps
-  ));
-` : ''}
-
-  float skirt = aSkirt;
-  float wall = 0.0;   // outer-perimeter skirt -> plinth wall
-  if (uInfiniteMode < 0.5) {
-    if (uUseTiles > 0.5) {
-      if (uTileShape > 0.5) {
-        if (aWall > 0.5) {
-          // Dedicated radial wall: top follows the same single analytic
-          // terrain sample; the base ring drops to the plinth.
-          wall = aSkirt;
-          skirt = 0.0;
-        } else {
-          // Retain both terrain-toned crack covers. Either neighbour can be
-          // the finer LOD, so fixed-side ownership can expose a T-junction.
-          skirt = aSkirt;
-          wall = 0.0;
-        }
-      } else {
-        // multi-cell square assembly: only skirts on a cell edge facing empty
-        // space become the plinth wall; shared seams stay continuous terrain.
-        vec3 tw = tileWall(wp.xz);
-        float onOuter = step(0.5, tw.x);
-        skirt = aSkirt;
-        wall = aSkirt * onOuter;
-        skirt *= 1.0 - onOuter;
-        wp.xz += tw.yz * (wall * uWallThickness);
-      }
-    } else {
-      float bx = abs(wp.x);
-      float bz = abs(wp.z);
-      float onOuter = step(uBoardHalf - 1.0, bx) + step(uBoardHalf - 1.0, bz);
-      // outer-edge skirt verts become the plinth wall; interior skirts unchanged
-      wall = skirt * step(0.5, onOuter);
-      skirt *= 1.0 - step(0.5, onOuter);
-      // flare the wall base outward (away from the board) so it sits OUTSIDE the
-      // water plane edge — no z-fighting with the water, and it leans over any
-      // terrain edge that dips below the waterline so the side never shows through.
-      vec2 outDir = vec2(step(uBoardHalf - 1.0, bx) * sign(wp.x),
-                         step(uBoardHalf - 1.0, bz) * sign(wp.z));
-      wp.xz += outDir * (wall * uWallThickness);
-    }
-  }
-
-  // interior skirt drops by uSkirtDepth; the perimeter wall drops all the way to
-  // the plinth base so the terrain's own edge masks the under-the-map view at
-  // whatever LOD the border chunks are rendered at.
-  wp.y = mix(h - skirt * uSkirtDepth, uPlinthBaseY, wall);
-
-  vWorldPos = wp.xyz;
-  vLod = aLod;
-  vSkirt = max(skirt, wall);
-  vWall = wall;
-  vWallMesh = aWall;
-
-  gl_Position = projectionMatrix * viewMatrix * wp;
-}
-`;
-};
 
 const DEFAULT_TERRAIN_GRAPH_COLOR_GLSL = /* glsl */ `
 vec3 applyTerrainGraphColor(vec3 fallback, vec2 xz, float h01, float slope, float detail, float moisture) {
@@ -383,48 +296,175 @@ function resolveTerrainVariant(variant = 'full') {
     // With zero Manual paint coverage the atlas graph is a provable no-op.
     // Preserve the exact terrain/detail result and defer that large graph until
     // a surface-paint tool or loaded document actually needs it.
-    return { name: 'manual-empty', detail: true, surface: false, manual: true };
+    return { name: 'manual-empty', detail: true, surface: false, manual: true, manualSurface: false };
   }
   if (variant === 'manual') {
-    return { name: 'manual', detail: true, surface: true, manual: true };
+    return { name: 'manual', detail: true, surface: true, manual: true, manualSurface: true };
   }
   if (variant === 'hybrid-surface') {
-    return { name: 'hybrid-surface', detail: false, surface: true, manual: false, tileOnly: true };
+    return { name: 'hybrid-surface', detail: false, surface: true, manual: false, manualSurface: true, tileOnly: true };
   }
   if (variant === 'hybrid') {
-    return { name: 'hybrid', detail: true, surface: true, manual: false, tileOnly: true };
+    return { name: 'hybrid', detail: true, surface: true, manual: false, manualSurface: true, tileOnly: true };
   }
-  if (variant === 'base') return { name: 'base', detail: false, surface: false };
-  if (variant === 'detail') return { name: 'detail', detail: true, surface: false };
-  if (variant === 'surface') return { name: 'surface', detail: false, surface: true };
-  return { name: 'full', detail: true, surface: true, manual: false };
+  if (variant === 'base') return { name: 'base', detail: false, surface: false, manualSurface: false };
+  if (variant === 'detail') return { name: 'detail', detail: true, surface: false, manualSurface: false };
+  if (variant === 'surface') return { name: 'surface', detail: false, surface: true, manualSurface: false };
+  return { name: 'full', detail: true, surface: true, manual: false, manualSurface: false };
 }
+
+const resolveTerrainWorldMode = (worldMode) => (
+  worldMode === 'infinite' || worldMode === 'shared' ? worldMode : 'studio'
+);
+
+const buildTerrainCacheGLSL = (features, worldMode) => {
+  if (features.manual) return MANUAL_TERRAIN_CACHE_GLSL;
+  if (features.tileOnly || worldMode === 'studio') return HYBRID_TILE_TERRAIN_CACHE_GLSL;
+  return worldMode === 'infinite'
+    ? INFINITE_FIELD_CACHE_STRICT_GLSL
+    : INFINITE_FIELD_CACHE_GLSL;
+};
+
+const buildVertex = (heightGLSL, variant = 'full', requestedWorldMode = 'studio') => {
+  const worldMode = resolveTerrainWorldMode(requestedWorldMode);
+  const features = resolveTerrainVariant(variant);
+  const manual = features.manual;
+  const terrainCacheGLSL = buildTerrainCacheGLSL(features, worldMode);
+  const commonUniformsGLSL = manual ? MANUAL_COMMON_UNIFORMS_GLSL : TERRAIN_COMMON_UNIFORMS_GLSL;
+  const preview = variant === 'preview';
+  return /* glsl */ `
+${commonUniformsGLSL}
+${NOISE_GLSL}
+${BIOME_GLSL}
+${heightGLSL}
+${terrainCacheGLSL}
+
+uniform float uSkirtDepth;
+uniform float uPlinthBaseY;
+uniform float uWallThickness;
+${preview ? 'uniform float uEps;' : ''}
+
+attribute float aSkirt;
+attribute float aLod;
+attribute float aWall;   // 1 on the dedicated circular radial-wall mesh, else 0
+
+varying vec3  vWorldPos;
+varying float vLod;
+varying float vSkirt;
+varying float vWall;
+varying float vWallMesh;
+${preview ? 'varying vec3 vTerrainPreviewNormal;' : ''}
+
+void main() {
+  vec4 localPosition = vec4(position, 1.0);
+  #ifdef USE_INSTANCING
+    localPosition = instanceMatrix * localPosition;
+  #endif
+  vec4 wp = modelMatrix * localPosition;
+  float h = terrainCachedHeightAt(wp.xz);
+${preview ? /* glsl */ `
+  // Smooth lighting for the lightweight Node preview. Two extra height
+  // samples per vertex are much cheaper than evaluating the graph per pixel,
+  // and interpolate cleanly across the visible terrain triangles.
+  float normalEps = max(uEps, 0.001);
+  float hNormalX = terrainCachedHeightAt(wp.xz + vec2(normalEps, 0.0));
+  float hNormalZ = terrainCachedHeightAt(wp.xz + vec2(0.0, normalEps));
+  vTerrainPreviewNormal = normalize(vec3(
+    -(hNormalX - h) / normalEps,
+    1.0,
+    -(hNormalZ - h) / normalEps
+  ));
+` : ''}
+
+  float skirt = aSkirt;
+  float wall = 0.0;   // outer-perimeter skirt -> plinth wall
+  if (uInfiniteMode < 0.5) {
+    if (uUseTiles > 0.5) {
+      if (uTileShape > 0.5) {
+        if (aWall > 0.5) {
+          // Dedicated radial wall: top follows the same single analytic
+          // terrain sample; the base ring drops to the plinth.
+          wall = aSkirt;
+          skirt = 0.0;
+        } else {
+          // Retain both terrain-toned crack covers. Either neighbour can be
+          // the finer LOD, so fixed-side ownership can expose a T-junction.
+          skirt = aSkirt;
+          wall = 0.0;
+        }
+      } else {
+        // multi-cell square assembly: only skirts on a cell edge facing empty
+        // space become the plinth wall; shared seams stay continuous terrain.
+        vec3 tw = tileWall(wp.xz);
+        float onOuter = step(0.5, tw.x);
+        skirt = aSkirt;
+        wall = aSkirt * onOuter;
+        skirt *= 1.0 - onOuter;
+        wp.xz += tw.yz * (wall * uWallThickness);
+      }
+    } else {
+      float bx = abs(wp.x);
+      float bz = abs(wp.z);
+      float onOuter = step(uBoardHalf - 1.0, bx) + step(uBoardHalf - 1.0, bz);
+      // outer-edge skirt verts become the plinth wall; interior skirts unchanged
+      wall = skirt * step(0.5, onOuter);
+      skirt *= 1.0 - step(0.5, onOuter);
+      // flare the wall base outward (away from the board) so it sits OUTSIDE the
+      // water plane edge — no z-fighting with the water, and it leans over any
+      // terrain edge that dips below the waterline so the side never shows through.
+      vec2 outDir = vec2(step(uBoardHalf - 1.0, bx) * sign(wp.x),
+                         step(uBoardHalf - 1.0, bz) * sign(wp.z));
+      wp.xz += outDir * (wall * uWallThickness);
+    }
+  }
+
+  // interior skirt drops by uSkirtDepth; the perimeter wall drops all the way to
+  // the plinth base so the terrain's own edge masks the under-the-map view at
+  // whatever LOD the border chunks are rendered at.
+  wp.y = mix(h - skirt * uSkirtDepth, uPlinthBaseY, wall);
+
+  vWorldPos = wp.xyz;
+  vLod = aLod;
+  vSkirt = max(skirt, wall);
+  vWall = wall;
+  vWallMesh = aWall;
+
+  gl_Position = projectionMatrix * viewMatrix * wp;
+}
+`;
+};
 
 const buildFragment = (
   heightGLSL,
   graphColorGLSL = DEFAULT_TERRAIN_GRAPH_COLOR_GLSL,
   variant = 'full',
+  requestedWorldMode = 'studio',
 ) => {
+  const worldMode = resolveTerrainWorldMode(requestedWorldMode);
   const features = resolveTerrainVariant(variant);
+  const terrainCacheGLSL = buildTerrainCacheGLSL(features, worldMode);
+  const commonUniformsGLSL = features.manual
+    ? MANUAL_COMMON_UNIFORMS_GLSL
+    : TERRAIN_COMMON_UNIFORMS_GLSL;
+  const terrainHeightGLSL = features.manual || worldMode === 'infinite'
+    ? ''
+    : TERRAIN_HEIGHT_TEX_GLSL;
+  const climateCacheGLSL = features.manual
+    ? MANUAL_TERRAIN_CLIMATE_GLSL
+    : worldMode === 'shared' && !features.tileOnly
+      ? TERRAIN_CLIMATE_CACHE_GLSL
+      : '';
   return /* glsl */ `
 precision highp float;
 
-${features.manual ? MANUAL_COMMON_UNIFORMS_GLSL : COMMON_UNIFORMS_GLSL}
+${commonUniformsGLSL}
 ${features.manual ? '' : IMPORTED_IMAGERY_ALBEDO_GLSL}
 ${NOISE_GLSL}
 ${BIOME_GLSL}
 ${heightGLSL}
-${features.manual ? '' : TERRAIN_HEIGHT_TEX_GLSL}
-${features.manual
-    ? MANUAL_TERRAIN_CACHE_GLSL
-    : features.tileOnly
-      ? HYBRID_TILE_TERRAIN_CACHE_GLSL
-      : INFINITE_FIELD_CACHE_GLSL}
-${features.manual
-    ? MANUAL_TERRAIN_CLIMATE_GLSL
-    : features.tileOnly
-      ? ''
-      : TERRAIN_CLIMATE_CACHE_GLSL}
+${terrainHeightGLSL}
+${terrainCacheGLSL}
+${climateCacheGLSL}
 ${PALETTE_UNIFORMS_GLSL}
 ${TERRAIN_COLOR_FUNCTIONS_GLSL}
 ${graphColorGLSL}
@@ -1024,7 +1064,7 @@ void main() {
 }
 `;
 
-// 1x1 mid-grey fallback so the four surface-texture samplers are always bound
+// 1x1 mid-grey fallback so the two surface-texture samplers are always bound
 // (avoids "no texture" warnings while the real atlas is null / before build).
 let _surfFallbackTex = null;
 function surfFallbackTexture() {
@@ -1317,22 +1357,25 @@ export function createTerrainMaterial(
   options = {},
 ) {
   const variant = resolveTerrainVariant(options.variant).name;
+  const worldMode = resolveTerrainWorldMode(options.worldMode);
   const h = resolveTerrainVariant(variant).manual
     ? MANUAL_HEIGHT_GLSL
     : buildHeightGLSL(stackGLSL.body2d);
   const material = new THREE.ShaderMaterial({
     uniforms,
     defines: { OCTAVES: octaves },
-    vertexShader: buildVertex(h, variant),
+    vertexShader: buildVertex(h, variant, worldMode),
     fragmentShader: buildFragment(
       h,
       stackGLSL.colorBody || DEFAULT_TERRAIN_GRAPH_COLOR_GLSL,
       variant,
+      worldMode,
     ),
     side: THREE.DoubleSide,
     extensions: { derivatives: true },
   });
   material.userData.terrainVariant = variant;
+  material.userData.terrainWorldMode = worldMode;
   material.userData.heightProgramSig = stackGLSL.sig;
   return material;
 }
@@ -1343,9 +1386,14 @@ export function createInfiniteTerrainMaterial(
   stackGLSL = DEFAULT_STACK_GLSL,
   options = {},
 ) {
-  // A distinct material object keeps mode ownership/disposal simple, while the
-  // identical source + defines let Three.js reuse Tile's compiled GPU program.
-  return createTerrainMaterial(uniforms, octaves, stackGLSL, options);
+  // A distinct material object keeps mode ownership/disposal simple. Infinite
+  // uses a cache-only source, while Studio uses the Tile analytic/bake source;
+  // keeping those programs separate is necessary to avoid reserving both
+  // worlds' sampler sets in a custom-surface fragment shader.
+  return createTerrainMaterial(uniforms, octaves, stackGLSL, {
+    ...options,
+    worldMode: options.worldMode ?? 'infinite',
+  });
 }
 
 /**
@@ -1375,17 +1423,20 @@ export function createBootTerrainMaterial(uniforms, octaves = 7, stackGLSL = DEF
 // served from three's cache.
 export function rebuildTerrainShaderSource(mat, stackGLSL, options = {}) {
   const variant = resolveTerrainVariant(options.variant).name;
+  const worldMode = resolveTerrainWorldMode(options.worldMode ?? mat?.userData?.terrainWorldMode);
   const h = resolveTerrainVariant(variant).manual
     ? MANUAL_HEIGHT_GLSL
     : buildHeightGLSL(stackGLSL.body2d);
-  mat.vertexShader = buildVertex(h, variant);
+  mat.vertexShader = buildVertex(h, variant, worldMode);
   mat.fragmentShader = buildFragment(
     h,
     stackGLSL.colorBody || DEFAULT_TERRAIN_GRAPH_COLOR_GLSL,
     variant,
+    worldMode,
   );
   mat.userData.minimalFragment = false;   // boot materials upgrade to the full fragment here
   mat.userData.terrainVariant = variant;
+  mat.userData.terrainWorldMode = worldMode;
   mat.userData.heightProgramSig = stackGLSL.sig;
   mat.extensions ||= {};
   mat.extensions.derivatives = true;

--- a/src/engine/terrain/surface/SurfaceAtlasBridge.js
+++ b/src/engine/terrain/surface/SurfaceAtlasBridge.js
@@ -1,0 +1,67 @@
+import { SURFACE_TEXTURE_ROLES, SURFACE_TEXTURE_VARIANT_COUNT } from './SurfaceTextureRoles.js';
+import { SURFACE_TEXTURE_SOURCE, normalizeSurfaceTextureSource } from './SurfaceTextureSources.js';
+
+const SLOTS = ['diffuse', 'normalDX', 'roughness', 'ao'];
+
+export function surfaceAtlasSuperseded() {
+  return Object.assign(new Error('A newer surface bake replaced this request.'), {
+    code: 'SURFACE_ATLAS_SUPERSEDED',
+  });
+}
+
+// The UI owns the upload URLs. Send immutable, structured-cloneable Blobs, not
+// the UI's module-local Map or URLs that replacing an upload can revoke.
+export async function captureSurfaceAtlasMaps(source, { resolveUrl, signal } = {}) {
+  if (normalizeSurfaceTextureSource({ surfaceTextureSource: source }) !== SURFACE_TEXTURE_SOURCE.CUSTOM) return null;
+  const resolve = resolveUrl || (await import('./SurfaceLibrary.js')).resolveCustomMapUrl;
+  const maps = {};
+  const reads = new Map();
+  const pending = [];
+  for (const role of SURFACE_TEXTURE_ROLES) {
+    maps[role.id] = Array.from({ length: SURFACE_TEXTURE_VARIANT_COUNT }, () => ({}));
+    for (let variant = 0; variant < SURFACE_TEXTURE_VARIANT_COUNT; variant += 1) {
+      for (const slot of SLOTS) {
+        const url = resolve(role.id, slot, variant);
+        if (!url) continue;
+        if (!reads.has(url)) {
+          reads.set(url, fetch(url, { signal }).then((response) => {
+            if (!response.ok) throw new Error(`Could not read uploaded texture (${response.status}).`);
+            return response.blob();
+          }));
+        }
+        pending.push(reads.get(url).then((blob) => {
+          maps[role.id][variant][slot] = blob;
+        }).catch((cause) => {
+          if (signal?.aborted) throw cause;
+          throw new Error(`Could not read ${role.label} V${variant + 1} ${slot}. Please upload that map again.`, { cause });
+        }));
+      }
+    }
+  }
+  await Promise.all(pending);
+  return maps;
+}
+
+// Keep Three.js resources inside the renderer. Only the UI-facing metadata is
+// returned across the worker boundary; a rejected stale build owns its cleanup.
+export async function buildAndInstallSurfaceAtlas(engine, source, customMaps, {
+  isCurrent = () => true,
+  buildAtlas,
+} = {}) {
+  if (!isCurrent()) throw surfaceAtlasSuperseded();
+  const build = buildAtlas || (await import('./applyTerrainSurface.js')).buildActiveSurfaceAtlas;
+  const atlas = await build({ source, customMaps });
+  if (!isCurrent()) {
+    atlas.diffuse?.dispose();
+    atlas.props?.dispose();
+    throw surfaceAtlasSuperseded();
+  }
+  engine.setSurfaceAtlas(atlas, source);
+  return {
+    anyPresent: !!atlas.anyPresent,
+    bakedAt: atlas.bakedAt,
+    coverage: atlas.coverage,
+    layers: atlas.layers,
+    source,
+  };
+}

--- a/src/engine/terrain/surface/SurfaceAtlasBridge.js
+++ b/src/engine/terrain/surface/SurfaceAtlasBridge.js
@@ -11,17 +11,42 @@ export function surfaceAtlasSuperseded() {
 
 // The UI owns the upload URLs. Send immutable, structured-cloneable Blobs, not
 // the UI's module-local Map or URLs that replacing an upload can revoke.
-export async function captureSurfaceAtlasMaps(source, { resolveUrl, signal } = {}) {
+async function collectSurfaceAtlasMapRefs(source, { resolveUrl, signal } = {}) {
   if (normalizeSurfaceTextureSource({ surfaceTextureSource: source }) !== SURFACE_TEXTURE_SOURCE.CUSTOM) return null;
   const resolve = resolveUrl || (await import('./SurfaceLibrary.js')).resolveCustomMapUrl;
   const maps = {};
-  const reads = new Map();
-  const pending = [];
   for (const role of SURFACE_TEXTURE_ROLES) {
     maps[role.id] = Array.from({ length: SURFACE_TEXTURE_VARIANT_COUNT }, () => ({}));
     for (let variant = 0; variant < SURFACE_TEXTURE_VARIANT_COUNT; variant += 1) {
       for (const slot of SLOTS) {
         const url = resolve(role.id, slot, variant);
+        if (!url) continue;
+        maps[role.id][variant][slot] = url;
+      }
+    }
+  }
+  // Abort as soon as the user changes source or cancels; this helper may
+  // execute while the upload source is transiently reconfigured.
+  if (signal?.aborted) throw Object.assign(new Error('Engine command cancelled'), { code: 'ENGINE_COMMAND_CANCELLED' });
+  return maps;
+}
+
+export async function captureSurfaceAtlasMapRefs(source, { resolveUrl, signal } = {}) {
+  return collectSurfaceAtlasMapRefs(source, { resolveUrl, signal });
+}
+
+// Legacy path for environments that need immutable blobs to cross the boundary.
+// This remains for environments that cannot (or should not) fetch object URLs
+// from the renderer worker.
+export async function captureSurfaceAtlasMaps(source, { resolveUrl, signal } = {}) {
+  const maps = await collectSurfaceAtlasMapRefs(source, { resolveUrl, signal });
+  if (!maps) return null;
+  const reads = new Map();
+  const pending = [];
+  for (const role of SURFACE_TEXTURE_ROLES) {
+    for (let variant = 0; variant < SURFACE_TEXTURE_VARIANT_COUNT; variant += 1) {
+      for (const slot of SLOTS) {
+        const url = maps[role.id]?.[variant]?.[slot];
         if (!url) continue;
         if (!reads.has(url)) {
           reads.set(url, fetch(url, { signal }).then((response) => {

--- a/src/engine/terrain/surface/SurfaceTextureAtlas.js
+++ b/src/engine/terrain/surface/SurfaceTextureAtlas.js
@@ -25,22 +25,50 @@ function atlasTileSize(rowCount) {
   return tile;
 }
 
-function loadImage(url) {
+async function loadImage(input) {
+  if (!input) return null;
+  // Image is a Window API. The render worker receives Blobs from the UI;
+  // built-in assets still arrive as URLs and use the same worker decoder.
+  if (typeof Image === 'undefined') {
+    if (typeof createImageBitmap !== 'function') throw new Error('Surface baking requires an image decoder.');
+    try {
+      let blob = input;
+      if (!(input instanceof Blob)) {
+        const response = await fetch(input);
+        if (!response.ok || (response.headers.get('content-type') || '').includes('text/html')) return null;
+        blob = await response.blob();
+      }
+      return await createImageBitmap(blob);
+    } catch {
+      return null; // Keep per-map missing/optional diagnostics on decode failure.
+    }
+  }
   return new Promise((resolve) => {
-    if (!url) { resolve(null); return; }
+    const objectUrl = input instanceof Blob ? URL.createObjectURL(input) : null;
     const img = new Image();
+    const finish = (result) => {
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+      resolve(result);
+    };
     img.crossOrigin = 'anonymous';
-    img.onload = () => resolve(img);
-    img.onerror = () => resolve(null);
-    img.src = url;
+    img.onload = () => finish(img);
+    img.onerror = () => finish(null);
+    img.src = objectUrl || input;
   });
 }
 
-function makeAtlasCanvas(tile) {
-  const c = document.createElement('canvas');
-  c.width = tile;
-  c.height = tile * SURFACE_TEXTURE_ROWS;
+function makeCanvas(width, height) {
+  const c = typeof Image === 'undefined' && typeof OffscreenCanvas !== 'undefined'
+    ? new OffscreenCanvas(width, height)
+    : document.createElement('canvas');
+  c.width = width;
+  c.height = height;
+  if (!c.getContext('2d')) throw new Error('Surface baking could not create a 2D canvas.');
   return c;
+}
+
+function makeAtlasCanvas(tile) {
+  return makeCanvas(tile, tile * SURFACE_TEXTURE_ROWS);
 }
 
 function fillMissingDiffuseRow(ctx, row, tile, materialId, variantIndex) {
@@ -80,17 +108,15 @@ function cellHash(x, y, salt) {
 }
 
 function drawImageCoverCell(ctx, img, x, y, w, h, salt) {
-  const rot = Math.floor(cellHash(x, y, salt + 1) * 4);
-  const mirrorX = cellHash(x, y, salt + 2) < 0.5 ? -1 : 1;
-  const mirrorY = cellHash(x, y, salt + 3) < 0.5 ? -1 : 1;
+  // Preserve tangent-space normal directions: crop/scale every map together
+  // instead of rotating or mirroring pixels without transforming normal XY.
   const scale = 1.12 + cellHash(x, y, salt + 4) * 0.26;
   ctx.save();
   ctx.beginPath();
   ctx.rect(x, y, w, h);
   ctx.clip();
   ctx.translate(x + w * 0.5, y + h * 0.5);
-  ctx.rotate(rot * Math.PI * 0.5);
-  ctx.scale(mirrorX * scale, mirrorY * scale);
+  ctx.scale(scale, scale);
   ctx.drawImage(img, -w * 0.58, -h * 0.58, w * 1.16, h * 1.16);
   ctx.restore();
 }
@@ -133,9 +159,7 @@ function makeAtlasTexture(canvas, { srgb }) {
 }
 
 function packPropertiesCanvas(canvases) {
-  const packed = document.createElement('canvas');
-  packed.width = canvases.normalDX.width;
-  packed.height = canvases.normalDX.height;
+  const packed = makeCanvas(canvases.normalDX.width, canvases.normalDX.height);
   const packedCtx = packed.getContext('2d');
   const normal = canvases.normalDX.getContext('2d').getImageData(0, 0, packed.width, packed.height).data;
   const roughness = canvases.roughness.getContext('2d').getImageData(0, 0, packed.width, packed.height).data;
@@ -151,7 +175,7 @@ function packPropertiesCanvas(canvases) {
   return packed;
 }
 
-// resolveUrl(materialId, slot, variantIndex) -> string|null
+// resolveUrl(materialId, slot, variantIndex) -> string|Blob|null
 // tilingFor(materialId) -> number
 export async function buildSurfaceAtlas({ source, resolveUrl, tilingFor, labelFor }) {
   const tileSize = atlasTileSize(SURFACE_TEXTURE_ROWS);
@@ -174,94 +198,100 @@ export async function buildSurfaceAtlas({ source, resolveUrl, tilingFor, labelFo
     const variants = new Array(SURFACE_TEXTURE_VARIANT_COUNT);
     const variantImages = new Array(SURFACE_TEXTURE_VARIANT_COUNT);
 
-    await Promise.all(Array.from({ length: SURFACE_TEXTURE_VARIANT_COUNT }, async (_, variantIndex) => {
-      const row = surfaceAtlasRow(roleIndex, variantIndex);
-      const imgs = {};
-      await Promise.all(SLOTS.map(async (slot) => {
-        imgs[slot] = await loadImage(resolveUrl(role.id, slot, variantIndex));
+    try {
+      await Promise.all(Array.from({ length: SURFACE_TEXTURE_VARIANT_COUNT }, async (_, variantIndex) => {
+        const row = surfaceAtlasRow(roleIndex, variantIndex);
+        const imgs = {};
+        await Promise.all(SLOTS.map(async (slot) => {
+          imgs[slot] = await loadImage(resolveUrl(role.id, slot, variantIndex));
+        }));
+        variantImages[variantIndex] = imgs;
+        const missingSlots = SLOTS.filter((slot) => !imgs[slot]);
+        const missingOptionalSlots = missingSlots.filter((slot) => slot !== 'diffuse');
+        const hasDiffuse = !!imgs.diffuse;
+        const status = !hasDiffuse ? 'missingDiffuse' : missingOptionalSlots.length ? 'missingOptional' : 'ready';
+        present[row] = hasDiffuse ? 1 : 0;
+        variants[variantIndex] = {
+          index: variantIndex,
+          row,
+          status,
+          hasDiffuse,
+          missingSlots,
+          missingOptionalSlots,
+        };
+        for (const slot of SLOTS) {
+          fillRow(ctx[slot], row, tileSize, imgs[slot], FALLBACK[slot], {
+            missingDiffuse: slot === 'diffuse' && !hasDiffuse,
+            materialId: role.id,
+            variantIndex,
+          });
+        }
       }));
-      variantImages[variantIndex] = imgs;
-      const missingSlots = SLOTS.filter((slot) => !imgs[slot]);
-      const missingOptionalSlots = missingSlots.filter((slot) => slot !== 'diffuse');
-      const hasDiffuse = !!imgs.diffuse;
-      const status = !hasDiffuse ? 'missingDiffuse' : missingOptionalSlots.length ? 'missingOptional' : 'ready';
-      present[row] = hasDiffuse ? 1 : 0;
-      variants[variantIndex] = {
-        index: variantIndex,
-        row,
+
+      // The shader samples row 0 for each role. Fold uploaded variants into that
+      // render row so the GLSL stays stable while variants still contribute.
+      const renderVariantIndex = variants.findIndex((variant) => variant.hasDiffuse);
+      const readyVariantImages = variants
+        .filter((variant) => variant.hasDiffuse)
+        .map((variant) => variantImages[variant.index]);
+      if (readyVariantImages.length > 1) {
+        const renderRow = surfaceAtlasRow(roleIndex, 0);
+        for (const slot of SLOTS) {
+          bakeVariantMosaicRow(
+            ctx[slot],
+            renderRow,
+            tileSize,
+            readyVariantImages,
+            slot,
+            FALLBACK[slot],
+            roleIndex * 17.31 // One layout for diffuse, normals, roughness and AO.
+          );
+        }
+        present[renderRow] = 1;
+      } else if (renderVariantIndex > 0) {
+        const renderRow = surfaceAtlasRow(roleIndex, 0);
+        const imgs = variantImages[renderVariantIndex] || {};
+        for (const slot of SLOTS) {
+          fillRow(ctx[slot], renderRow, tileSize, imgs[slot], FALLBACK[slot], {
+            missingDiffuse: false,
+            materialId: role.id,
+            variantIndex: renderVariantIndex,
+          });
+        }
+        present[renderRow] = 1;
+      }
+
+      const readyVariants = variants.filter((variant) => variant.hasDiffuse).length;
+      const completeVariants = variants.filter((variant) => variant.status === 'ready').length;
+      const missingOptionalSlots = [...new Set(variants.flatMap((variant) => (
+        variant.hasDiffuse ? variant.missingOptionalSlots : []
+      )))];
+      const status = readyVariants === 0
+        ? 'missingDiffuse'
+        : missingOptionalSlots.length
+          ? 'missingOptional'
+          : 'ready';
+      layers[roleIndex] = {
+        id: role.id,
+        name: labelFor?.(role.id) ?? role.label ?? role.id,
+        groupId: role.groupId,
+        groupLabel: role.groupLabel,
+        row: surfaceAtlasRow(roleIndex, 0),
+        roleIndex,
         status,
-        hasDiffuse,
-        missingSlots,
+        hasDiffuse: readyVariants > 0,
+        readyVariants,
+        completeVariants,
+        variantCount: SURFACE_TEXTURE_VARIANT_COUNT,
+        missingSlots: status === 'missingDiffuse' ? ['diffuse'] : [],
         missingOptionalSlots,
+        variants,
       };
-      for (const slot of SLOTS) {
-        fillRow(ctx[slot], row, tileSize, imgs[slot], FALLBACK[slot], {
-          missingDiffuse: slot === 'diffuse' && !hasDiffuse,
-          materialId: role.id,
-          variantIndex,
-        });
+    } finally {
+      for (const images of variantImages) {
+        for (const image of Object.values(images || {})) image?.close?.();
       }
-    }));
-
-    // The shader samples row 0 for each role. Fold uploaded variants into that
-    // render row so the GLSL stays stable while variants still contribute.
-    const renderVariantIndex = variants.findIndex((variant) => variant.hasDiffuse);
-    const readyVariantImages = variants
-      .filter((variant) => variant.hasDiffuse)
-      .map((variant) => variantImages[variant.index]);
-    if (readyVariantImages.length > 1) {
-      const renderRow = surfaceAtlasRow(roleIndex, 0);
-      for (const slot of SLOTS) {
-        bakeVariantMosaicRow(
-          ctx[slot],
-          renderRow,
-          tileSize,
-          readyVariantImages,
-          slot,
-          FALLBACK[slot],
-          roleIndex * 17.31 + slot.length * 5.7
-        );
-      }
-      present[renderRow] = 1;
-    } else if (renderVariantIndex > 0) {
-      const renderRow = surfaceAtlasRow(roleIndex, 0);
-      const imgs = variantImages[renderVariantIndex] || {};
-      for (const slot of SLOTS) {
-        fillRow(ctx[slot], renderRow, tileSize, imgs[slot], FALLBACK[slot], {
-          missingDiffuse: false,
-          materialId: role.id,
-          variantIndex: renderVariantIndex,
-        });
-      }
-      present[renderRow] = 1;
     }
-
-    const readyVariants = variants.filter((variant) => variant.hasDiffuse).length;
-    const completeVariants = variants.filter((variant) => variant.status === 'ready').length;
-    const missingOptionalSlots = [...new Set(variants.flatMap((variant) => (
-      variant.hasDiffuse ? variant.missingOptionalSlots : []
-    )))];
-    const status = readyVariants === 0
-      ? 'missingDiffuse'
-      : missingOptionalSlots.length
-        ? 'missingOptional'
-        : 'ready';
-    layers[roleIndex] = {
-      id: role.id,
-      name: labelFor?.(role.id) ?? role.label ?? role.id,
-      groupId: role.groupId,
-      groupLabel: role.groupLabel,
-      row: surfaceAtlasRow(roleIndex, 0),
-      roleIndex,
-      status,
-      hasDiffuse: readyVariants > 0,
-      readyVariants,
-      completeVariants,
-      variantCount: SURFACE_TEXTURE_VARIANT_COUNT,
-      missingSlots: status === 'missingDiffuse' ? ['diffuse'] : [],
-      missingOptionalSlots,
-      variants,
-    };
   }));
 
   const diffuseReady = layers.filter((layer) => layer.hasDiffuse).length;

--- a/src/engine/terrain/surface/SurfaceTextureDetector.js
+++ b/src/engine/terrain/surface/SurfaceTextureDetector.js
@@ -1,19 +1,30 @@
-// Guesses which map slot a dropped/imported file belongs to, from its filename.
-// Used by drag-and-drop in the Surface Library so a user can drop a batch of
-// files from a third-party texture pack without manually picking each slot.
+// Match map labels in the basename, not parent folders. Underscores are word
+// characters in regexes, so normalize separators before using word boundaries.
 const SLOT_PATTERNS = [
-  { slot: 'displacement', re: /(displacement|_disp\b|heightmap|height[_-]?map|\bheight\b)/i },
-  { slot: 'normalDX', re: /(normal[_-]?dx|normaldx|nor[_-]?dx|_nor[_-]?dx_|\bnormal\b|\bnrm\b|\bnorm\b)/i },
-  { slot: 'roughness', re: /(roughness|_rough_|\brough\b)/i },
-  { slot: 'ao', re: /(ambient[_-]?occlusion|\bocclusion\b|_ao_|\bao\b)/i },
-  { slot: 'diffuse', re: /(base[_-]?color|albedo|diffuse|_diff_|\bdiff\b|\bcolou?r\b|\bcol\b)/i },
+  { slot: 'displacement', re: /\b(displacement|disp|height\s*map|height)\b/i },
+  { slot: 'normalDX', re: /\b(normal\s*(?:dx|directx)|nor\s*dx|normal|nrm|norm)\b/i },
+  { slot: 'roughness', re: /\b(roughness|rough)\b/i },
+  { slot: 'ao', re: /\b(ambient\s*occlusion|occlusion|ao)\b/i },
+  { slot: 'diffuse', re: /\b(base\s*colou?r|albedo|diffuse|diff|colou?r|col)\b/i },
 ];
 
-// Returns one of the SurfaceLibrary map slot keys, or null if nothing matched.
-export function detectSlotFromFilename(filename) {
-  const name = filename.toLowerCase();
+export function describeTextureFilename(filename) {
+  const basename = String(filename).replace(/\\/g, '/').split('/').pop();
+  const name = basename.replace(/\.[^.]+$/, '')
+    .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+    .replace(/[_.-]+/g, ' ').toLowerCase();
+  // The normal slot is DirectX. Do not silently interpret GL normals as DX.
+  if (/\b(?:normal|nor)\s*(?:gl|opengl)\b/.test(name)) return null;
   for (const { slot, re } of SLOT_PATTERNS) {
-    if (re.test(name)) return slot;
+    if (!re.test(name)) continue;
+    const setName = name.replace(re, ' ')
+      .replace(/\b(?:\d+k|\d{3,5}(?:x\d{3,5})?)\b/g, ' ')
+      .trim().replace(/\s+/g, ' ');
+    return { slot, setName };
   }
   return null;
+}
+
+export function detectSlotFromFilename(filename) {
+  return describeTextureFilename(filename)?.slot ?? null;
 }

--- a/src/engine/terrain/surface/SurfaceTextureImport.js
+++ b/src/engine/terrain/surface/SurfaceTextureImport.js
@@ -1,0 +1,61 @@
+import { describeTextureFilename } from './SurfaceTextureDetector.js';
+import { SURFACE_TEXTURE_VARIANT_COUNT } from './SurfaceTextureRoles.js';
+
+export const SURFACE_IMAGE_EXT_RE = /\.(png|jpe?g|webp|avif|gif|bmp)$/i;
+
+export function mimeForSurfaceTexture(name) {
+  const extension = name.toLowerCase().split('.').pop();
+  return ({ png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg', webp: 'image/webp',
+    avif: 'image/avif', gif: 'image/gif', bmp: 'image/bmp' })[extension] || 'application/octet-stream';
+}
+
+// Entries can come from loose files or any depth inside a ZIP. The caller
+// supplies the archive name as scope so separate archives cannot mix their maps.
+// Group only by explicit path/name; never guess the target terrain role.
+export function collectSurfaceTextureSets(entries, mapSlots) {
+  const groups = new Map();
+  const unmatched = [];
+  for (const entry of entries) {
+    const path = entry.name.replace(/\\/g, '/');
+    const parts = path.split('/');
+    if (parts.some((part) => part.startsWith('.') || part === '__MACOSX')) continue;
+    const info = describeTextureFilename(path);
+    if (!SURFACE_IMAGE_EXT_RE.test(path)) {
+      if (info) unmatched.push(`${entry.name}: unsupported image format`);
+      continue;
+    }
+    if (!info || !mapSlots.includes(info.slot)) {
+      unmatched.push(`${entry.name}: unrecognized or unsupported map type`);
+      continue;
+    }
+    const directory = parts.slice(0, -1).join('/').toLowerCase();
+    const key = JSON.stringify([entry.scope || '', directory, info.setName]);
+    if (!groups.has(key)) groups.set(key, { name: info.setName || directory || entry.scope || 'Material', maps: new Map() });
+    const group = groups.get(key);
+    if (group.maps.has(info.slot)) {
+      unmatched.push(`${entry.name}: duplicate ${info.slot} in ${group.name}`);
+      continue;
+    }
+    group.maps.set(info.slot, entry);
+  }
+  return { sets: [...groups.values()], unmatched };
+}
+
+// The first set belongs to the explicitly chosen variant. Additional sets use
+// only wholly empty variants, including slots holding optional maps. Never
+// overwrite another variant or wrap an overflowing pack back to V1.
+export function planSurfaceTextureImport(sets, variantIndex, isEmpty) {
+  const assignments = [];
+  const unmatched = [];
+  const available = Array.from({ length: SURFACE_TEXTURE_VARIANT_COUNT }, (_, index) => index)
+    .filter((index) => index !== variantIndex && isEmpty(index));
+  for (const [index, set] of sets.entries()) {
+    const target = index === 0 ? variantIndex : available.shift();
+    if (!Number.isInteger(target) || target < 0 || target >= SURFACE_TEXTURE_VARIANT_COUNT) {
+      unmatched.push(`${set.name}: no empty variant available; open a variant to replace it`);
+      continue;
+    }
+    for (const [slot, entry] of set.maps) assignments.push({ ...entry, slot, variantIndex: target });
+  }
+  return { assignments, unmatched };
+}

--- a/src/engine/terrain/surface/applyTerrainSurface.js
+++ b/src/engine/terrain/surface/applyTerrainSurface.js
@@ -5,9 +5,9 @@ import { buildSurfaceAtlas } from './SurfaceTextureAtlas.js';
 import { SURFACE_TEXTURE_SOURCE, normalizeSurfaceTextureSource } from './SurfaceTextureSources.js';
 
 // Builds the terrain surface atlas from the CURRENTLY selected variants /
-// overrides in the Surface Library. Returns the atlas (4 THREE textures +
-// present/tile arrays) ready to hand to Engine.setSurfaceAtlas().
-export async function buildActiveSurfaceAtlas({ source = SURFACE_TEXTURE_SOURCE.CUSTOM } = {}) {
+// overrides in the Surface Library, or an explicit snapshot supplied by the
+// UI to the renderer worker. Returns two textures plus coverage metadata.
+export async function buildActiveSurfaceAtlas({ source = SURFACE_TEXTURE_SOURCE.CUSTOM, customMaps } = {}) {
   const normalizedSource = normalizeSurfaceTextureSource({ surfaceTextureSource: source });
   const manifest = await loadMaterialsManifest();
   const manifestById = Object.fromEntries((manifest.materials || []).map((material) => [material.id, material]));
@@ -16,7 +16,11 @@ export async function buildActiveSurfaceAtlas({ source = SURFACE_TEXTURE_SOURCE.
   const resolveUrl = (materialId, slot, variantIndex = 0) => {
     const mat = byId[materialId];
     if (!mat) return null;
-    if (normalizedSource === SURFACE_TEXTURE_SOURCE.CUSTOM) return resolveCustomMapUrl(mat, slot, variantIndex);
+    if (normalizedSource === SURFACE_TEXTURE_SOURCE.CUSTOM) {
+      // An explicitly empty snapshot must not read stale renderer-local state.
+      if (customMaps != null) return customMaps[materialId]?.[variantIndex]?.[slot] ?? null;
+      return resolveCustomMapUrl(mat, slot, variantIndex);
+    }
     if (normalizedSource === SURFACE_TEXTURE_SOURCE.BUILT_IN) {
       const material = manifestById[MANUAL_SURFACE_ASSET_BY_ROLE[materialId]];
       return material ? getDefaultMapUrl(material, slot) : null;

--- a/src/engine/terrain/terrainGLSL.js
+++ b/src/engine/terrain/terrainGLSL.js
@@ -370,13 +370,16 @@ vec2 manualSurfaceUvAt(vec2 xz) {
 vec4 manualSurfaceWeightsAAt(vec2 xz) {
   vec2 uv = manualSurfaceUvAt(xz);
   if (any(lessThan(uv, vec2(0.0))) || any(greaterThan(uv, vec2(1.0)))) return vec4(0.0);
-  return texture2D(uManualSurfaceTextureA, uv);
+  // Manual Terrain's packed maps are bound to the existing paint biome/props
+  // units while Manual mode is active. Reusing those units avoids adding a
+  // second sampler pair to the terrain surface program.
+  return texture2D(uPaintBiomeTexture, uv);
 }
 
 vec4 manualSurfaceWeightsBAt(vec2 xz) {
   vec2 uv = manualSurfaceUvAt(xz);
   if (any(lessThan(uv, vec2(0.0))) || any(greaterThan(uv, vec2(1.0)))) return vec4(0.0);
-  return texture2D(uManualSurfaceTextureB, uv);
+  return texture2D(uPaintPropsTexture, uv);
 }
 `;
 

--- a/src/manual/ManualSurfacePaintField.js
+++ b/src/manual/ManualSurfacePaintField.js
@@ -63,6 +63,7 @@ export class ManualSurfacePaintField {
     this._uploadAPending = false;
     this._uploadBPending = false;
     this._boundUniforms = null;
+    this._aliasPaintTextures = false;
     this._scratchCurrent = new Float32Array(CHANNEL_COUNT);
     this._scratchNext = new Float32Array(CHANNEL_COUNT);
     this._scratchAverage = new Float32Array(CHANNEL_COUNT);
@@ -85,11 +86,19 @@ export class ManualSurfacePaintField {
     this.textureB.version = previousTextureB.version;
     previousTextureA.dispose();
     previousTextureB.dispose();
-    if (this._boundUniforms) {
-      this._boundUniforms.uManualSurfaceTextureA.value = this.textureA;
-      this._boundUniforms.uManualSurfaceTextureB.value = this.textureB;
-    }
+    this._bindTexturesToUniforms();
     return true;
+  }
+
+  _bindTexturesToUniforms() {
+    if (!this._boundUniforms) return;
+    const uniforms = this._boundUniforms;
+    if (uniforms.uManualSurfaceTextureA) uniforms.uManualSurfaceTextureA.value = this.textureA;
+    if (uniforms.uManualSurfaceTextureB) uniforms.uManualSurfaceTextureB.value = this.textureB;
+    if (this._aliasPaintTextures) {
+      if (uniforms.uPaintBiomeTexture) uniforms.uPaintBiomeTexture.value = this.textureA;
+      if (uniforms.uPaintPropsTexture) uniforms.uPaintPropsTexture.value = this.textureB;
+    }
   }
 
   _readBounds() {
@@ -173,11 +182,11 @@ export class ManualSurfacePaintField {
     return this._syncBounds();
   }
 
-  bind(uniforms) {
+  bind(uniforms, { aliasPaintTextures = false } = {}) {
     if (!uniforms) return;
     this._boundUniforms = uniforms;
-    uniforms.uManualSurfaceTextureA.value = this.textureA;
-    uniforms.uManualSurfaceTextureB.value = this.textureB;
+    this._aliasPaintTextures = aliasPaintTextures === true;
+    this._bindTexturesToUniforms();
     this._applyBoundsToUniforms();
   }
 

--- a/tests/SurfaceCustomMaterials.regression.test.js
+++ b/tests/SurfaceCustomMaterials.regression.test.js
@@ -1,0 +1,300 @@
+import { afterEach, describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { detectSlotFromFilename } from '../src/engine/terrain/surface/SurfaceTextureDetector.js';
+import { collectSurfaceTextureSets, planSurfaceTextureImport } from '../src/engine/terrain/surface/SurfaceTextureImport.js';
+import { captureSurfaceAtlasMaps, buildAndInstallSurfaceAtlas } from '../src/engine/terrain/surface/SurfaceAtlasBridge.js';
+import { buildSurfaceAtlas } from '../src/engine/terrain/surface/SurfaceTextureAtlas.js';
+import { SURFACE_TEXTURE_ROLES, surfaceAtlasRow } from '../src/engine/terrain/surface/SurfaceTextureRoles.js';
+
+const source = 'customTextures';
+const slots = ['diffuse', 'normalDX', 'roughness', 'ao'];
+const entry = (name, scope = '') => ({ name, scope, blob: new Blob([name]) });
+const savedGlobals = new Map();
+const urls = [];
+function replaceGlobal(key, value) {
+  if (!savedGlobals.has(key)) savedGlobals.set(key, Object.getOwnPropertyDescriptor(globalThis, key));
+  Object.defineProperty(globalThis, key, { configurable: true, writable: true, value });
+}
+afterEach(() => {
+  for (const [key, descriptor] of savedGlobals) {
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else delete globalThis[key];
+  }
+  savedGlobals.clear();
+  for (const url of urls.splice(0)) URL.revokeObjectURL(url);
+});
+
+function blobUrl(text) {
+  const url = URL.createObjectURL(new Blob([text], { type: 'image/png' }));
+  urls.push(url);
+  return url;
+}
+
+class CanvasContext {
+  constructor(canvas) { this.canvas = canvas; this.draws = []; this.labels = []; }
+  drawImage(image, ...args) { this.draws.push({ image, args }); }
+  fillRect() {}
+  fillText(text) { this.labels.push(text); }
+  save() {}
+  restore() {}
+  beginPath() {}
+  rect() {}
+  clip() {}
+  translate() {}
+  scale() {}
+  getImageData(_x, _y, width, height) { return this.createImageData(width, height); }
+  createImageData(width, height) { return { data: new Uint8ClampedArray(width * height * 4) }; }
+  putImageData() {}
+}
+class Canvas {
+  constructor(width = 1, height = 1) {
+    this.width = width;
+    this.height = height;
+    this.context = new CanvasContext(this);
+    Canvas.instances.push(this);
+  }
+  getContext() { return this.context; }
+}
+Canvas.instances = [];
+
+function workerCanvasEnvironment() {
+  Canvas.instances = [];
+  const decoded = [];
+  replaceGlobal('Image', undefined);
+  replaceGlobal('document', undefined);
+  replaceGlobal('OffscreenCanvas', Canvas);
+  replaceGlobal('createImageBitmap', async (blob) => {
+    const tag = await blob.text();
+    if (tag === 'corrupt') throw new Error('Invalid image');
+    const image = { tag, closed: false, close() { this.closed = true; } };
+    decoded.push(image);
+    return image;
+  });
+  return decoded;
+}
+const bake = (resolveUrl) => buildSurfaceAtlas({ source, resolveUrl, tilingFor: () => 12 });
+
+// The import planner is deliberately independent of ZIP decoding and React.
+describe('custom texture import regression', () => {
+  it('recognizes common underscore, hyphen, camel-case and legacy pack labels', () => {
+    for (const [name, slot] of [
+      ['grass_Color.png', 'diffuse'], ['grass_BaseColor.jpg', 'diffuse'],
+      ['grass_Albedo.png', 'diffuse'], ['grass_diff_1k.jpg', 'diffuse'],
+      ['grass_Normal.png', 'normalDX'], ['grass_NormalDX.png', 'normalDX'],
+      ['grass_nor_dx_1k.jpg', 'normalDX'], ['grass_NRM.png', 'normalDX'],
+      ['grass_Rough.png', 'roughness'], ['grass_Roughness.png', 'roughness'],
+      ['grass_AO.png', 'ao'], ['grass_AmbientOcclusion.png', 'ao'],
+      ['grass_Height.png', 'displacement'],
+    ]) assert.equal(detectSlotFromFilename(name), slot, name);
+  });
+
+  it('ignores map words in directories and does not relabel OpenGL normals as DX', () => {
+    assert.equal(detectSlotFromFilename('normal/roughness/grass_Color.png'), 'diffuse');
+    assert.equal(detectSlotFromFilename('C:\\roughness\\grass_AO.png'), 'ao');
+    assert.equal(detectSlotFromFilename('grass_NormalGL.png'), null);
+    assert.equal(detectSlotFromFilename('grass_nor_gl.png'), null);
+    assert.equal(detectSlotFromFilename('grass.png'), null);
+  });
+
+  it('groups maps at ZIP root and in nested variant folders without a textures/ requirement', () => {
+    const result = collectSurfaceTextureSets([
+      entry('grass_Color.png'), entry('grass_NormalDX.png'), entry('grass_AO.png'),
+      entry('pack/variant2/grass_Color.png'), entry('pack/variant2/grass_Roughness.png'),
+    ], slots);
+    assert.equal(result.sets.length, 2);
+    assert.deepEqual([...result.sets[0].maps.keys()], ['diffuse', 'normalDX', 'ao']);
+    assert.deepEqual([...result.sets[1].maps.keys()], ['diffuse', 'roughness']);
+    assert.deepEqual(result.unmatched, []);
+  });
+
+  it('keeps separate archive scopes and explicit filename variants separate', () => {
+    const result = collectSurfaceTextureSets([
+      entry('grass_diff_1k.png', 'first.zip'), entry('grass_nor_dx_2k.png', 'first.zip'),
+      entry('grass_diff_1k.png', 'second.zip'), entry('grass_v2_diff_1k.png', 'first.zip'),
+    ], slots);
+    assert.equal(result.sets.length, 3);
+    assert.equal(result.sets[0].maps.size, 2);
+  });
+
+  it('reports duplicate/unsupported maps and ignores archive metadata', () => {
+    const result = collectSurfaceTextureSets([
+      entry('__MACOSX/._grass_Color.png'), entry('.hidden/grass_Color.png'),
+      entry('grass_Color.png'), entry('grass_diff_2k.png'),
+      entry('grass_NormalGL.png'), entry('grass_Height.exr'), entry('README.txt'),
+    ], slots);
+    assert.equal(result.sets.length, 1);
+    assert.equal(result.sets[0].maps.size, 1);
+    assert.equal(result.unmatched.length, 3);
+    assert.match(result.unmatched[0], /duplicate/);
+  });
+
+  it('fills empty variants without overwriting other uploads, including optional-only variants', () => {
+    const { sets } = collectSurfaceTextureSets(['a', 'b', 'c'].map((s) => entry(`${s}_Color.png`)), slots);
+    const plan = planSurfaceTextureImport(sets, 2, (i) => i === 1 || i === 3);
+    assert.deepEqual(plan.assignments.map((a) => a.variantIndex), [2, 1, 3]);
+    assert.deepEqual(plan.unmatched, []);
+  });
+
+  it('reports overflow instead of dropping variants silently or wrapping to V1', () => {
+    const { sets } = collectSurfaceTextureSets(['a', 'b', 'c', 'd', 'e'].map((s) => entry(`${s}_Color.png`)), slots);
+    const plan = planSurfaceTextureImport(sets, 0, () => true);
+    assert.deepEqual(plan.assignments.map((a) => a.variantIndex), [0, 1, 2, 3]);
+    assert.equal(plan.unmatched.length, 1);
+    assert.match(plan.unmatched[0], /no empty variant/);
+  });
+});
+
+describe('UI to render-worker surface snapshot', () => {
+  it('sends all populated roles/variants as cloneable Blobs that outlive UI URLs', async () => {
+    const url = blobUrl('custom pixels');
+    const maps = await captureSurfaceAtlasMaps(source, {
+      resolveUrl: (role, slot, variant) => role === 'grass' && slot === 'diffuse' && variant === 2 ? url : null,
+    });
+    URL.revokeObjectURL(url);
+    const copied = structuredClone(maps);
+    assert.equal(await copied.grass[2].diffuse.text(), 'custom pixels');
+    assert.deepEqual(copied.grass[0], {});
+    assert.deepEqual(copied.sand[2], {});
+    assert.equal(Object.keys(copied).length, 13);
+  });
+
+  it('deduplicates reads of shared upload URLs', async () => {
+    const originalFetch = globalThis.fetch;
+    let reads = 0;
+    replaceGlobal('fetch', (...args) => { reads += 1; return originalFetch(...args); });
+    const url = blobUrl('shared');
+    const maps = await captureSurfaceAtlasMaps(source, {
+      resolveUrl: (role, slot) => role === 'grass' && slot === 'diffuse' ? url : null,
+    });
+    assert.equal(reads, 1);
+    assert.equal(maps.grass[0].diffuse, maps.grass[3].diffuse);
+  });
+
+  it('represents removal as an explicit empty snapshot, not a renderer-local fallback', async () => {
+    const maps = await captureSurfaceAtlasMaps(source, { resolveUrl: () => null });
+    assert.equal(Object.values(maps).flat().every((variant) => !Object.keys(variant).length), true);
+    assert.equal(await captureSurfaceAtlasMaps('builtInTextures'), null);
+    assert.equal(await captureSurfaceAtlasMaps('procedural'), null);
+  });
+
+  it('reports the failing role/variant/map instead of sending a broken snapshot', async () => {
+    await assert.rejects(captureSurfaceAtlasMaps(source, {
+      resolveUrl: (role, slot, variant) => role === 'grass' && slot === 'ao' && variant === 1 ? 'blob:missing-texture' : null,
+    }), /Grass V2 ao/);
+  });
+
+  it('honors cancellation while capturing files', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const url = blobUrl('cancelled');
+    await assert.rejects(captureSurfaceAtlasMaps(source, {
+      signal: controller.signal,
+      resolveUrl: (role, slot, variant) => role === 'grass' && slot === 'diffuse' && variant === 0 ? url : null,
+    }), { name: 'AbortError' });
+  });
+
+  it('installs renderer-owned textures and returns only UI metadata', async () => {
+    const maps = { grass: [{ diffuse: new Blob(['pixels']) }] };
+    const atlas = { anyPresent: true, coverage: { diffuseReady: 1 }, layers: [], bakedAt: 123, diffuse: {}, props: {} };
+    let installed;
+    const result = await buildAndInstallSurfaceAtlas({ setSurfaceAtlas: (...args) => { installed = args; } }, source, maps, {
+      buildAtlas: async (options) => { assert.equal(options.customMaps, maps); return atlas; },
+    });
+    assert.deepEqual(installed, [atlas, source]);
+    assert.equal(result.anyPresent, true);
+    assert.equal(result.source, source);
+    assert.equal('diffuse' in result, false);
+    assert.equal('props' in result, false);
+    assert.deepEqual(structuredClone(result), result);
+  });
+
+  it('does not start an already superseded bake', async () => {
+    let builds = 0;
+    await assert.rejects(buildAndInstallSurfaceAtlas({}, source, {}, {
+      isCurrent: () => false, buildAtlas: async () => { builds += 1; },
+    }), { code: 'SURFACE_ATLAS_SUPERSEDED' });
+    assert.equal(builds, 0);
+  });
+
+  it('disposes stale results instead of installing them over newer uploads', async () => {
+    let checks = 0;
+    let disposed = 0;
+    let installs = 0;
+    await assert.rejects(buildAndInstallSurfaceAtlas({ setSurfaceAtlas: () => { installs += 1; } }, source, {}, {
+      isCurrent: () => ++checks === 1,
+      buildAtlas: async () => ({ diffuse: { dispose: () => { disposed += 1; } }, props: { dispose: () => { disposed += 1; } } }),
+    }), { code: 'SURFACE_ATLAS_SUPERSEDED' });
+    assert.equal(disposed, 2);
+    assert.equal(installs, 0);
+  });
+});
+
+describe('surface atlas worker image decoding and sparse variants', () => {
+  it('bakes a single non-first variant without Image or document and closes its bitmap', async () => {
+    const decoded = workerCanvasEnvironment();
+    const atlas = await bake((role, slot, variant) => role === 'grass' && slot === 'diffuse' && variant === 2 ? new Blob(['grass-v3']) : null);
+    const layer = atlas.layers.find((item) => item.id === 'grass');
+    assert.equal(layer.readyVariants, 1);
+    assert.equal(layer.variants[2].hasDiffuse, true);
+    assert.equal(layer.status, 'missingOptional');
+    assert.equal(atlas.coverage.diffuseReady, 1);
+    const row = surfaceAtlasRow(SURFACE_TEXTURE_ROLES.findIndex((role) => role.id === 'grass'), 0);
+    assert.equal(atlas.present[row], 1);
+    assert.equal(atlas.diffuse.image.context.draws.some((draw) => draw.image.tag === 'grass-v3' && draw.args[1] === row * atlas.atlasTileSize), true);
+    assert.equal(decoded.length, 1);
+    assert.equal(decoded[0].closed, true);
+    assert.equal(atlas.diffuse.flipY, false);
+  });
+
+  it('accepts one diffuse per role; missing extra variants and optional maps do not block rendering', async () => {
+    workerCanvasEnvironment();
+    const atlas = await bake((role, slot, variant) => slot === 'diffuse' && variant === 0 ? new Blob([role]) : null);
+    assert.equal(atlas.coverage.diffuseReady, 13);
+    assert.equal(atlas.coverage.missingDiffuse, 0);
+    assert.equal(atlas.anyPresent, true);
+    assert.equal(atlas.layers.every((layer) => layer.readyVariants === 1), true);
+  });
+
+  it('keeps the same variant/crop layout in diffuse, normal, roughness and AO mosaic rows', async () => {
+    const decoded = workerCanvasEnvironment();
+    await bake((role, slot, variant) => role === 'grass' && (variant === 0 || variant === 2) ? new Blob([`${variant}:${slot}`]) : null);
+    const layouts = Canvas.instances.slice(0, 4).map((canvas) =>
+      canvas.context.draws.slice(-16).map((draw) => `${draw.image.tag.split(':')[0]}:${draw.args.join(',')}`)
+    );
+    assert.equal(layouts[0].length, 16);
+    for (const layout of layouts.slice(1)) assert.deepEqual(layout, layouts[0]);
+    assert.equal(decoded.every((image) => image.closed), true);
+  });
+
+  it('marks a corrupt uploaded diffuse as missing instead of claiming it was baked', async () => {
+    workerCanvasEnvironment();
+    const atlas = await bake((role, slot, variant) => role === 'grass' && slot === 'diffuse' && variant === 0 ? new Blob(['corrupt']) : null);
+    assert.equal(atlas.anyPresent, false);
+    assert.equal(atlas.layers.find((layer) => layer.id === 'grass').status, 'missingDiffuse');
+  });
+
+  it('loads built-in URL images in the worker too', async () => {
+    workerCanvasEnvironment();
+    const url = blobUrl('builtin');
+    const atlas = await bake((role, slot, variant) => role === 'sand' && slot === 'diffuse' && variant === 0 ? url : null);
+    assert.equal(atlas.coverage.diffuseReady, 1);
+  });
+
+  it('preserves the main-thread Image/canvas path', async () => {
+    Canvas.instances = [];
+    replaceGlobal('Image', class {
+      set src(value) { this.tag = value; queueMicrotask(() => this.onload()); }
+    });
+    replaceGlobal('document', { createElement: () => new Canvas() });
+    replaceGlobal('createImageBitmap', () => { throw new Error('Must use Image on the main thread'); });
+    const atlas = await bake((role, slot, variant) => role === 'grass' && slot === 'diffuse' && variant === 0 ? 'grass.png' : null);
+    assert.equal(atlas.anyPresent, true);
+    assert.equal(atlas.coverage.diffuseReady, 1);
+  });
+
+  it('produces an actionable error when a 2D context cannot be created', async () => {
+    workerCanvasEnvironment();
+    replaceGlobal('OffscreenCanvas', class { getContext() { return null; } });
+    await assert.rejects(bake(() => null), /could not create a 2D canvas/);
+  });
+});

--- a/tests/TerrainMaterial.test.js
+++ b/tests/TerrainMaterial.test.js
@@ -19,8 +19,8 @@ afterEach(() => {
 describe('shared Tile and Infinite terrain program', () => {
   it('builds byte-identical full shader programs for both modes', () => {
     const uniforms = createTerrainUniforms();
-    const tile = createTerrainMaterial(uniforms, 7);
-    const infinite = createInfiniteTerrainMaterial(uniforms, 7);
+    const tile = createTerrainMaterial(uniforms, 7, undefined, { worldMode: 'shared' });
+    const infinite = createInfiniteTerrainMaterial(uniforms, 7, undefined, { worldMode: 'shared' });
     materials.push(tile, infinite);
 
     expect(infinite).not.toBe(tile);
@@ -36,8 +36,8 @@ describe('shared Tile and Infinite terrain program', () => {
 
   it('uses one runtime mode uniform instead of preprocessor variants', () => {
     const uniforms = createTerrainUniforms();
-    const tile = createTerrainMaterial(uniforms, 5);
-    const infinite = createInfiniteTerrainMaterial(uniforms, 5);
+    const tile = createTerrainMaterial(uniforms, 5, undefined, { worldMode: 'shared' });
+    const infinite = createInfiniteTerrainMaterial(uniforms, 5, undefined, { worldMode: 'shared' });
     materials.push(tile, infinite);
 
     expect(uniforms.uInfiniteMode.value).toBe(0);
@@ -64,7 +64,7 @@ describe('shared Tile and Infinite terrain program', () => {
 
   it('returns fully initialized climate structs on every cache path', () => {
     const uniforms = createTerrainUniforms();
-    const material = createTerrainMaterial(uniforms, 5);
+    const material = createTerrainMaterial(uniforms, 5, undefined, { worldMode: 'shared' });
     materials.push(material);
 
     const start = material.fragmentShader.indexOf('Climate terrainCachedClimateAt');
@@ -222,7 +222,7 @@ describe('shared Tile and Infinite terrain program', () => {
 
   it('exposes manual surface weight maps and blends painted material roles', () => {
     const uniforms = createTerrainUniforms();
-    const tile = createTerrainMaterial(uniforms, 5);
+    const tile = createTerrainMaterial(uniforms, 5, undefined, { worldMode: 'studio' });
     materials.push(tile);
 
     expect(uniforms.uManualSurfaceMode.value).toBe(0);
@@ -231,8 +231,9 @@ describe('shared Tile and Infinite terrain program', () => {
     expect(tile.fragmentShader).toContain('manualSurfaceWeightsAAt(wpos.xz)');
     expect(tile.fragmentShader).toContain('manualSurfaceWeightsBAt(wpos.xz)');
     const fragmentSamplers = [...tile.fragmentShader.matchAll(/uniform\s+sampler(?:2D|Cube)\s+([A-Za-z0-9_]+)/g)];
-    // Rolling caches plus the independent Destruction Lab height/scorch field.
-    expect(fragmentSamplers).toHaveLength(23);
+    // Studio keeps only the Tile bake path; Manual weights reuse the paint
+    // biome/props units and the unused spline auxiliary map is omitted.
+    expect(fragmentSamplers).toHaveLength(16);
     expect(tile.fragmentShader).toContain('destructionScorchAt(xz)');
     expect(tile.fragmentShader).toContain('uniform sampler2D uSurfProps');
     expect(tile.fragmentShader).not.toContain('uniform sampler2D uSurfAO');
@@ -253,8 +254,8 @@ describe('shared Tile and Infinite terrain program', () => {
 
     expect(manual.userData.terrainVariant).toBe('manual');
     expect(fragmentSamplers).toEqual([
-      'uManualSurfaceTextureA',
-      'uManualSurfaceTextureB',
+      'uPaintBiomeTexture',
+      'uPaintPropsTexture',
       'uManualHeightTexture',
       'uDestructionTexture',
       'uTileOccupancy',
@@ -262,8 +263,8 @@ describe('shared Tile and Infinite terrain program', () => {
       'uSurfProps',
     ]);
     expect(vertexSamplers).toEqual([
-      'uManualSurfaceTextureA',
-      'uManualSurfaceTextureB',
+      'uPaintBiomeTexture',
+      'uPaintPropsTexture',
       'uManualHeightTexture',
       'uDestructionTexture',
       'uTileOccupancy',
@@ -296,6 +297,8 @@ describe('shared Tile and Infinite terrain program', () => {
     expect(hybrid.fragmentShader).not.toContain('uniform sampler2D uInfiniteFieldTex0');
     expect(hybrid.fragmentShader).not.toContain('uniform sampler2D uTerrainBiomeTex');
     expect(hybrid.fragmentShader).not.toContain('infiniteFieldSampleAt');
+    expect(hybrid.fragmentShader).not.toContain('uniform sampler2D uManualSurfaceTextureA');
+    expect(hybrid.fragmentShader).not.toContain('uniform sampler2D uManualSurfaceTextureB');
     expect(hybrid.fragmentShader).toContain('return heightAt(xz);');
     expect(hybrid.fragmentShader).toContain('manualSurfaceWeightsAAt(wpos.xz)');
     expect(hybrid.fragmentShader).toContain('if (amount < 0.002) return res;');


### PR DESCRIPTION
## Summary
Fix the custom-material pipeline when rendering in a worker, and make texture-set imports and bake failures explicit. Based on main at `658d16494dc2c54d9da6bd0f7ae6bfe8961c764e`.

## Root causes addressed
- Upload overrides live in the UI's module-local SurfaceLibrary Map. The previous worker bake received only a source name and therefore could not see those uploads.
- The worker already provides a canvas shim, but the atlas loader still used the Window-only `Image` API.
- ZIP import required a `textures/` path and kept only the first image per map slot. Common underscore-separated filenames were also missed.
- Variant mosaics used different seeds for diffuse, normals, roughness and AO, selecting inconsistent material layouts.
- Bake errors were swallowed by the panel and could trigger repeated automatic retries without a useful error message.

## Changes
- Snapshot custom uploads as structured-cloneable Blobs on the UI thread and pass them to the renderer. An explicitly empty snapshot does not fall back to stale renderer-local state.
- Decode worker images with `createImageBitmap`, use OffscreenCanvas, close decoded bitmaps, and keep Three.js atlas resources inside the renderer. Preserve the main-thread Image/canvas path.
- Reject superseded worker bake results and dispose their textures; ignore outdated panel results.
- Import images at ZIP root or in nested folders. Group maps by explicit archive/folder/material stem, populate empty variants, and report duplicates, unsupported files and the four-variant limit instead of silently dropping them. Additional sets do not overwrite other occupied variants.
- Recognize common underscore/hyphen/camel-case map labels. Explicit OpenGL normals are not silently interpreted as DirectX normals.
- Use the same mosaic layout for every map and avoid rotating/mirroring normal pixels without transforming their vectors.
- Show bake errors with explicit retry, report closed-row import failures, and clarify that one diffuse per role is sufficient while extra variants and other maps are optional.

## Regression coverage and validation
Added `tests/SurfaceCustomMaterials.regression.test.js` with **22 tests** covering filename detection, ZIP-entry grouping, duplicate/overflow handling, non-overwrite behavior, Blob snapshots, removal/cancellation, stale-result disposal, sparse variants, worker decoding, map alignment, corrupt images and main-thread fallback.

**Completed:** all 22 tests passed in an isolated Node harness. That harness maps Vitest hooks to `node:test` and substitutes a minimal Three.js CanvasTexture/constants stub; canvas and image decoding are mocked by the tests. JavaScript syntax checks, JSX transpilation diagnostics and `git diff --check` passed.

**Not verified:** the repository's native Vitest run, full dependency suite, production build, real image pixels, or end-to-end WebGL rendering. Network restrictions prevented installing the full project dependencies. Local browser navigation was blocked, and an in-memory browser harness could not initialize the baseline worker, so there is no passing browser integration result to claim.

## Before merging
- [ ] Run `npm ci`, `npm test -- tests/SurfaceCustomMaterials.regression.test.js`, the full test suite, and `npm run build` in the normal project environment.
- [ ] In the default worker renderer, upload only a diffuse in V3 with V1/V2/V4 empty, bake, and verify the terrain uses it. Repeat with one diffuse per role.
- [ ] Check root/nested ZIPs containing multiple explicitly named sets; confirm extra sets fill empty variants, occupied variants are preserved, and overflow is reported.
- [ ] Verify rapid replacement/clear during baking, error display and retry, and the main-thread and built-in material paths.
- [ ] Check diffuse/normal/roughness/AO alignment visually with a multi-variant material.

## Scope limits
Uploads remain session-only; this does not add persistence across reloads or saved-project embedding. Packs still need explicit names/folders and must be dropped on the intended terrain role; this does not guess categories across an arbitrary asset pack. The original reported project/assets have not been reproduced here. No merge or deployment is included.